### PR TITLE
Add item numbers and section totals to BOQ layout

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -266,8 +266,11 @@ export const generatePDF = (data: DocumentData) => {
         .items th, .items td { border:1px solid #e6e6e6; padding:6px 8px; }
         .items thead th { background:hsl(var(--primary)); color:#fff; font-weight:700; }
         .section-row td.section-title { background:#f4f4f4; font-weight:700; padding:8px; }
-        .item-row td.desc { width:60%; }
+        .item-row td.num { text-align:center; }
+        .item-row td.desc { width:55%; }
         .item-row td.qty, .item-row td.unit, .item-row td.rate, .item-row td.amount { text-align:right; }
+        .section-total td { font-weight:700; background:#fafafa; }
+        .section-total .label { text-align:right; padding-right:12px; }
         .totals { margin-top:10px; width:100%; }
         .totals .label { text-align:right; padding-right:12px; }
         .footer { margin-top:24px; display:flex; flex-direction:column; gap:18px; }

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -326,7 +326,8 @@ export const generatePDF = (data: DocumentData) => {
         <table class="items">
           <thead>
             <tr>
-              <th style="width:60%; text-align:left">ITEM DESCRIPTION</th>
+              <th style="width:5%">#</th>
+              <th style="width:55%; text-align:left">ITEM DESCRIPTION</th>
               <th style="width:8%">QTY</th>
               <th style="width:9%">UNIT</th>
               <th style="width:11%">RATE</th>

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -322,8 +322,22 @@ export const generatePDF = (data: DocumentData) => {
         </div>
 
         <div class="footer">
-          <div class="sig">SIGNED: (CONTRACTOR)</div>
-          <div class="sig">SIGNED: (EMPLOYER)</div>
+          <div class="sig-block">
+            <div class="sig-title">SIGNED:</div>
+            <div class="sig-role">( CONTRACTOR )</div>
+            <div class="sigline"></div>
+            <div class="field-row"><div class="label">Address:</div><div class="fill"></div></div>
+            <div class="field-row"><div class="label">Tel No:</div><div class="fill"></div></div>
+            <div class="field-row"><div class="label">Date:</div><div class="fill"></div></div>
+          </div>
+          <div class="sig-block">
+            <div class="sig-title">SIGNED:</div>
+            <div class="sig-role">( EMPLOYER )</div>
+            <div class="sigline"></div>
+            <div class="field-row"><div class="label">Address:</div><div class="fill"></div></div>
+            <div class="field-row"><div class="label">Tel No:</div><div class="fill"></div></div>
+            <div class="field-row"><div class="label">Date:</div><div class="fill"></div></div>
+          </div>
         </div>
       </div>
       <div class="pagefoot">${company.name} • Generated on ${new Date().toLocaleDateString()}</div>

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -244,8 +244,14 @@ export const generatePDF = (data: DocumentData) => {
         .item-row td.qty, .item-row td.unit, .item-row td.rate, .item-row td.amount { text-align:right; }
         .totals { margin-top:10px; width:100%; }
         .totals .label { text-align:right; padding-right:12px; }
-        .footer { margin-top:24px; display:flex; justify-content:space-between; gap:20px; }
-        .sig { width:45%; border-top:1px solid #999; text-align:left; padding-top:6px; }
+        .footer { margin-top:24px; display:flex; flex-direction:column; gap:18px; }
+        .sig-block { display:flex; flex-direction:column; gap:8px; }
+        .sig-title { font-weight:700; }
+        .sig-role { font-weight:700; }
+        .sigline { height:16px; border-bottom:1px dotted #999; }
+        .field-row { display:flex; align-items:flex-end; gap:8px; }
+        .field-row .label { width:80px; font-weight:600; }
+        .field-row .fill { flex:1; height:16px; border-bottom:1px dotted #999; }
         .pagefoot { position:fixed; bottom:12mm; left:12mm; right:12mm; text-align:center; font-size:10px; color:#666; }
       </style>
     </head>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR enhances the BOQ (Bill of Quantities) PDF layout by:
- Adding item numbering for better organization and reference
- Including section totals to provide clearer cost breakdowns
- Restructuring the footer with detailed signature fields in a vertical layout

## Code changes

**BOQ Table Enhancements:**
- Added item number column (#) to the table header and rows
- Implemented automatic item numbering that resets for each section
- Added section total rows that calculate and display subtotals for each section
- Adjusted column widths to accommodate the new item number column

**Footer Restructuring:**
- Changed footer layout from horizontal to vertical arrangement
- Enhanced signature blocks with dedicated fields for Address, Tel No, and Date
- Added dotted lines for manual completion of signature details
- Improved styling with proper spacing and field labels

**Technical Implementation:**
- Added section total tracking with `flushSectionTotal()` function
- Implemented item counter that resets per section
- Updated CSS styles for new layout elements including `.section-total`, `.sig-block`, and `.field-row` classesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d9e88b5a2f2b4ee39cf3340bd431b881/mystic-haven)

👀 [Preview Link](https://d9e88b5a2f2b4ee39cf3340bd431b881-mystic-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d9e88b5a2f2b4ee39cf3340bd431b881</projectId>-->
<!--<branchName>mystic-haven</branchName>-->