### PR TITLE
Add display as progressive percentages flag to BOQ documents

### DIFF
--- a/src/components/invoices/CreateInvoiceModal.tsx
+++ b/src/components/invoices/CreateInvoiceModal.tsx
@@ -82,6 +82,7 @@ export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedC
   const [termsAndConditions, setTermsAndConditions] = useState('Payment due within 30 days of invoice date.');
   const [showCalculatedValuesInTerms, setShowCalculatedValuesInTerms] = useState(false);
   const [previousTermsLoaded, setPreviousTermsLoaded] = useState(false);
+  const [displayAsPercentage, setDisplayAsPercentage] = useState(false);
 
   const [sections, setSections] = useState<InvoiceSection[]>([]);
   const [searchProduct, setSearchProduct] = useState('');
@@ -474,6 +475,7 @@ export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedC
         currency: currency,
         terms_and_conditions: termsAndConditions,
         notes: notes,
+        display_as_percentage: displayAsPercentage,
         created_by: profile.id
       };
 
@@ -554,6 +556,7 @@ export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedC
     setLpoNumber('');
     setNotes('');
     setTermsAndConditions('Payment due within 30 days of invoice date.');
+    setDisplayAsPercentage(false);
     setSections([]);
     setSearchProduct('');
     setNewSectionName('');
@@ -684,6 +687,17 @@ export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedC
                       Show calculated values (e.g., 50% (KES 50,000))
                     </Label>
                   </div>
+                </div>
+
+                <div className="flex items-center space-x-2 pt-4 border-t">
+                  <Checkbox
+                    id="display-as-percentage"
+                    checked={displayAsPercentage}
+                    onCheckedChange={(checked) => setDisplayAsPercentage(!!checked)}
+                  />
+                  <Label htmlFor="display-as-percentage" className="font-medium cursor-pointer">
+                    Display as progressive percentages
+                  </Label>
                 </div>
               </CardContent>
             </Card>

--- a/src/components/proforma/CreateProformaModal.tsx
+++ b/src/components/proforma/CreateProformaModal.tsx
@@ -66,6 +66,7 @@ export const CreateProformaModal = ({
     valid_until: '',
     notes: '',
     terms_and_conditions: '',
+    display_as_percentage: false,
   });
 
   const [items, setItems] = useState<ProformaItem[]>([]);
@@ -246,6 +247,7 @@ export const CreateProformaModal = ({
         total_amount: totals.total,
         notes: formData.notes,
         terms_and_conditions: formData.terms_and_conditions,
+        display_as_percentage: formData.display_as_percentage,
       };
 
       // Convert items to proforma items format (simplified for current schema)
@@ -610,6 +612,17 @@ export const CreateProformaModal = ({
                 placeholder="Terms and conditions..."
                 rows={3}
               />
+            </div>
+
+            <div className="flex items-center space-x-2 pt-4 border-t">
+              <Checkbox
+                id="display-as-percentage"
+                checked={formData.display_as_percentage}
+                onCheckedChange={(checked) => setFormData(prev => ({ ...prev, display_as_percentage: !!checked }))}
+              />
+              <Label htmlFor="display-as-percentage" className="font-medium cursor-pointer">
+                Display as progressive percentages
+              </Label>
             </div>
           </div>
 

--- a/src/components/quotations/CreateQuotationModal.tsx
+++ b/src/components/quotations/CreateQuotationModal.tsx
@@ -76,6 +76,7 @@ export function CreateQuotationModal({ open, onOpenChange, onSuccess }: CreateQu
   const [notes, setNotes] = useState('');
   const [termsAndConditions, setTermsAndConditions] = useState('Payment due within 30 days of invoice date.');
   const [previousTermsLoaded, setPreviousTermsLoaded] = useState(false);
+  const [displayAsPercentage, setDisplayAsPercentage] = useState(false);
 
   const [sections, setSections] = useState<QuotationSection[]>([]);
   const [searchProduct, setSearchProduct] = useState('');
@@ -461,6 +462,7 @@ export function CreateQuotationModal({ open, onOpenChange, onSuccess }: CreateQu
         currency: currency,
         terms_and_conditions: termsAndConditions,
         notes: notes,
+        display_as_percentage: displayAsPercentage,
         created_by: profile.id
       };
       console.log('Quotation data prepared:', quotationData);
@@ -578,6 +580,7 @@ export function CreateQuotationModal({ open, onOpenChange, onSuccess }: CreateQu
     setCurrency('KES');
     setNotes('');
     setTermsAndConditions('Payment due within 30 days of invoice date.');
+    setDisplayAsPercentage(false);
     setSections([]);
     setSearchProduct('');
     setNewSectionName('');
@@ -691,6 +694,17 @@ export function CreateQuotationModal({ open, onOpenChange, onSuccess }: CreateQu
                     onChange={(e) => setTermsAndConditions(e.target.value)}
                     rows={3}
                   />
+                </div>
+
+                <div className="flex items-center space-x-2 pt-4 border-t">
+                  <Checkbox
+                    id="display-as-percentage"
+                    checked={displayAsPercentage}
+                    onCheckedChange={(checked) => setDisplayAsPercentage(!!checked)}
+                  />
+                  <Label htmlFor="display-as-percentage" className="font-medium cursor-pointer">
+                    Display as progressive percentages
+                  </Label>
                 </div>
               </CardContent>
             </Card>

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -413,6 +413,7 @@ export interface DocumentData {
   currency?: string; // Currency code: 'KES', 'USD', 'EUR'
   customTitle?: string; // Optional custom title for BOQ PDFs
   stampImageUrl?: string; // Optional stamp image URL for special PDFs
+  display_as_percentage?: boolean; // Whether to display calculated values instead of percentages in PDF
   customer: {
     name: string;
     email?: string;
@@ -526,7 +527,7 @@ const DEFAULT_COMPANY: CompanyDetails = {
 };
 
 // Helper function to determine which columns have values
-const analyzeColumns = (items: DocumentData['items']) => {
+const analyzeColumns = (items: DocumentData['items'], displayAsPercentage: boolean = false) => {
   if (!items || items.length === 0) return {};
 
   const columns = {
@@ -538,20 +539,38 @@ const analyzeColumns = (items: DocumentData['items']) => {
   };
 
   items.forEach(item => {
-    if (item.discount_percentage && item.discount_percentage > 0) {
-      columns.discountPercentage = true;
-    }
-    if (item.discount_before_vat && item.discount_before_vat > 0) {
-      columns.discountBeforeVat = true;
-    }
-    if (item.discount_amount && item.discount_amount > 0) {
-      columns.discountAmount = true;
-    }
-    if (item.tax_percentage && item.tax_percentage > 0) {
-      columns.taxPercentage = true;
-    }
-    if (item.tax_amount && item.tax_amount > 0) {
-      columns.taxAmount = true;
+    // When display_as_percentage is true, hide percentage columns and only show amounts
+    if (displayAsPercentage) {
+      // Hide percentage columns
+      columns.discountPercentage = false;
+      columns.taxPercentage = false;
+      // Show amount columns instead
+      if (item.discount_before_vat && item.discount_before_vat > 0) {
+        columns.discountBeforeVat = true;
+      }
+      if (item.discount_amount && item.discount_amount > 0) {
+        columns.discountAmount = true;
+      }
+      if (item.tax_amount && item.tax_amount > 0) {
+        columns.taxAmount = true;
+      }
+    } else {
+      // Original behavior when not display_as_percentage mode
+      if (item.discount_percentage && item.discount_percentage > 0) {
+        columns.discountPercentage = true;
+      }
+      if (item.discount_before_vat && item.discount_before_vat > 0) {
+        columns.discountBeforeVat = true;
+      }
+      if (item.discount_amount && item.discount_amount > 0) {
+        columns.discountAmount = true;
+      }
+      if (item.tax_percentage && item.tax_percentage > 0) {
+        columns.taxPercentage = true;
+      }
+      if (item.tax_amount && item.tax_amount > 0) {
+        columns.taxAmount = true;
+      }
     }
   });
 
@@ -799,7 +818,7 @@ export const generatePDF = async (data: DocumentData) => {
   console.log('📋 Company data:', company);
 
   // Analyze which columns have values
-  const visibleColumns = analyzeColumns(data.items);
+  const visibleColumns = analyzeColumns(data.items, data.display_as_percentage || false);
   const formatCurrency = (amount: number) => {
     return formatCurrencyUtil(amount, data.currency || 'KES');
   };

--- a/supabase/migrations/20240101_add_display_as_percentage.sql
+++ b/supabase/migrations/20240101_add_display_as_percentage.sql
@@ -1,0 +1,11 @@
+-- Add display_as_percentage field to quotations table
+ALTER TABLE IF EXISTS quotations 
+ADD COLUMN IF NOT EXISTS display_as_percentage BOOLEAN DEFAULT FALSE;
+
+-- Add display_as_percentage field to invoices table
+ALTER TABLE IF EXISTS invoices 
+ADD COLUMN IF NOT EXISTS display_as_percentage BOOLEAN DEFAULT FALSE;
+
+-- Add display_as_percentage field to proforma_invoices table
+ALTER TABLE IF EXISTS proforma_invoices 
+ADD COLUMN IF NOT EXISTS display_as_percentage BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
### Summary
Adds a `display_as_percentage` boolean flag to quotations, proformas, and invoices so that when enabled, generated PDFs show calculated currency values instead of percentage columns for tax and discount fields.

### Problem
There was no way to mark a BOQ/Quotation/Proforma as "percentage-based" for display purposes. When documents were converted to invoices and exported as PDFs, both percentage columns and calculated amount columns would appear simultaneously, with no user control over which representation to show.

### Solution
Introduced a single boolean flag (`display_as_percentage`) at the document level that controls the PDF rendering mode. When enabled, percentage columns are hidden and only calculated currency amount columns are shown. The flag is stored in the database and surfaced as a checkbox toggle in each document creation modal.

### Key Changes
- **Database migration** (`20240101_add_display_as_percentage.sql`): Adds `display_as_percentage BOOLEAN DEFAULT FALSE` column to `quotations`, `invoices`, and `proforma_invoices` tables.
- **PDF Generator** (`pdfGenerator.ts`):
  - Added `display_as_percentage` field to the `DocumentData` interface.
  - Updated `analyzeColumns()` to accept a `displayAsPercentage` parameter; when `true`, forces `discountPercentage` and `taxPercentage` columns to `false` and only enables amount-based columns (`discountAmount`, `taxAmount`, `discountBeforeVat`).
  - `generatePDF()` now passes the flag through to `analyzeColumns()`.
- **CreateInvoiceModal** (`CreateInvoiceModal.tsx`): Added `displayAsPercentage` state, wired to a new "Display as progressive percentages" checkbox, and included in the invoice save payload.
- **CreateProformaModal** (`CreateProformaModal.tsx`): Added `display_as_percentage` to form state and save payload, with a matching checkbox in the UI.
- **CreateQuotationModal** (`CreateQuotationModal.tsx`): Added `displayAsPercentage` state, wired to a new checkbox, and included in the quotation save payload.


---

<a href="https://builder.io/app/projects/272c03c62c17494db9454d2178a2eae7/striped-melody-lzk5m2sp"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://272c03c62c17494db9454d2178a2eae7-striped-melody-lzk5m2sp_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 227`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>272c03c62c17494db9454d2178a2eae7</projectId>-->
<!--<branchName>striped-melody-lzk5m2sp</branchName>-->