### PR TITLE
Add BOQ percentage display flag and PDF naming

### DIFF
--- a/src/components/proforma/CreateProformaModal.tsx
+++ b/src/components/proforma/CreateProformaModal.tsx
@@ -318,6 +318,7 @@ export const CreateProformaModal = ({
       valid_until: '',
       notes: '',
       terms_and_conditions: '',
+      display_as_percentage: false,
     });
     setItems([]);
     setSearchTerm('');

--- a/src/hooks/useProforma.ts
+++ b/src/hooks/useProforma.ts
@@ -568,27 +568,128 @@ export const useConvertProformaToInvoice = () => {
 
   return useMutation({
     mutationFn: async ({ proformaId, companyId }: { proformaId: string; companyId: string }) => {
-      // This would implement the conversion logic
-      // For now, just mark the proforma as converted
-      const { data, error } = await supabase
+      // Get proforma data with items
+      let query = supabase
         .from('proforma_invoices')
-        .update({ status: 'converted' })
-        .eq('id', proformaId)
-        .eq('company_id', companyId)
+        .select(`
+          *,
+          proforma_items(*)
+        `)
+        .eq('id', proformaId);
+
+      if (companyId) {
+        query = query.eq('company_id', companyId);
+      }
+
+      const { data: proforma, error: proformaError } = await query.single();
+
+      if (proformaError) throw proformaError;
+
+      // Generate invoice number
+      const { data: invoiceNumber } = await supabase.rpc('generate_invoice_number', {
+        company_uuid: proforma.company_id
+      });
+
+      // Determine creator
+      let createdBy: string | null = null;
+      try {
+        const { data: userData } = await supabase.auth.getUser();
+        createdBy = userData?.user?.id || null;
+      } catch {
+        createdBy = null;
+      }
+
+      // Create invoice from proforma, copying the display_as_percentage flag
+      const invoiceData = {
+        company_id: proforma.company_id,
+        customer_id: proforma.customer_id,
+        invoice_number: invoiceNumber,
+        invoice_date: new Date().toISOString().split('T')[0],
+        due_date: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+        status: 'sent',
+        subtotal: proforma.subtotal,
+        tax_amount: proforma.tax_amount,
+        total_amount: proforma.total_amount,
+        currency: 'KES',
+        notes: proforma.notes,
+        terms_and_conditions: proforma.terms_and_conditions,
+        created_by: createdBy,
+        balance_due: proforma.total_amount,
+        paid_amount: 0,
+        display_as_percentage: proforma.display_as_percentage || false
+      };
+
+      const { data: invoice, error: invoiceError } = await supabase
+        .from('invoices')
+        .insert([invoiceData])
         .select()
         .single();
 
-      if (error) {
-        console.error('Error converting proforma to invoice:', error);
-        throw error;
+      if (invoiceError) throw invoiceError;
+
+      // Create invoice items from proforma items
+      if (proforma.proforma_items && proforma.proforma_items.length > 0) {
+        const invoiceItems = proforma.proforma_items.map((item: any) => ({
+          invoice_id: invoice.id,
+          product_id: item.product_id,
+          description: item.description,
+          quantity: item.quantity,
+          unit_price: item.unit_price,
+          tax_percentage: item.tax_percentage,
+          tax_amount: item.tax_amount,
+          tax_inclusive: item.tax_inclusive,
+          line_total: item.line_total
+        }));
+
+        const { error: itemsError } = await supabase
+          .from('invoice_items')
+          .insert(invoiceItems);
+
+        if (itemsError) throw itemsError;
+
+        // Create stock movements for products
+        const stockMovements = invoiceItems
+          .filter(item => item.product_id && item.quantity > 0)
+          .map(item => ({
+            company_id: invoice.company_id,
+            product_id: item.product_id,
+            movement_type: 'OUT' as const,
+            reference_type: 'INVOICE' as const,
+            reference_id: invoice.id,
+            quantity: -item.quantity,
+            cost_per_unit: item.unit_price,
+            notes: `Stock reduction for invoice ${invoice.invoice_number} (converted from proforma ${proforma.proforma_number})`
+          }));
+
+        if (stockMovements.length > 0) {
+          await supabase.from('stock_movements').insert(stockMovements);
+
+          // Update product stock quantities
+          const stockUpdatePromises = stockMovements.map(movement =>
+            supabase.rpc('update_product_stock', {
+              product_uuid: movement.product_id,
+              movement_type: movement.movement_type,
+              quantity: Math.abs(movement.quantity)
+            })
+          );
+
+          await Promise.allSettled(stockUpdatePromises);
+        }
       }
 
-      return data;
+      // Update proforma status to converted
+      await supabase
+        .from('proforma_invoices')
+        .update({ status: 'converted' })
+        .eq('id', proformaId)
+        .eq('company_id', companyId);
+
+      return invoice;
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['proforma_invoices'] });
-      queryClient.invalidateQueries({ queryKey: ['proforma_invoice', data.id] });
-      toast.success(`Proforma invoice ${data.proforma_number} converted to invoice!`);
+      queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      toast.success(`Proforma invoice converted to invoice ${data.invoice_number}!`);
     },
     onError: (error) => {
       const errorMessage = serializeError(error);

--- a/src/hooks/useQuotationItems.ts
+++ b/src/hooks/useQuotationItems.ts
@@ -269,7 +269,8 @@ export const useConvertQuotationToInvoice = () => {
         terms_and_conditions: quotation.terms_and_conditions,
         created_by: createdBy,
         balance_due: quotation.total_amount,
-        paid_amount: 0
+        paid_amount: 0,
+        display_as_percentage: quotation.display_as_percentage || false
       };
 
       const { data: invoice, error: invoiceError } = await supabase

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -3716,6 +3716,7 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
       showCalculatedValuesInTerms: false, // Never show calculated values in invoice terms
       customTitle: 'INVOICE',
       project_title: projectTitle || undefined,
+      display_as_percentage: invoice.display_as_percentage || false,
     };
   } else {
     documentData = {
@@ -3745,6 +3746,7 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
       showCalculatedValuesInTerms: false, // Never show calculated values in invoice terms
       customTitle: 'INVOICE',
       project_title: projectTitle || undefined,
+      display_as_percentage: invoice.display_as_percentage || false,
     };
   }
 
@@ -3833,6 +3835,7 @@ export const downloadQuotationPDF = async (quotation: any, company?: CompanyDeta
       total_amount: quotation.total_amount,
       notes: quotation.notes,
       terms_and_conditions: quotation.terms_and_conditions,
+      display_as_percentage: quotation.display_as_percentage || false,
     };
   } else {
     documentData = {
@@ -3856,6 +3859,7 @@ export const downloadQuotationPDF = async (quotation: any, company?: CompanyDeta
       total_amount: quotation.total_amount,
       notes: quotation.notes,
       terms_and_conditions: quotation.terms_and_conditions,
+      display_as_percentage: quotation.display_as_percentage || false,
     };
   }
 

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -2571,9 +2571,16 @@ export const generatePDF = async (data: DocumentData) => {
       </html>
     `;
 
-    const filename = data.project_title
-      ? `${data.number}-${data.project_title}.pdf`
-      : `${data.number}.pdf`;
+    let filename: string;
+    if (data.type === 'receipt') {
+      filename = `RECEIPT - ${data.number}.pdf`;
+    } else if (data.type === 'invoice' && data.project_title) {
+      filename = `INVOICE - ${data.project_title}.pdf`;
+    } else if (data.project_title) {
+      filename = `${data.number}-${data.project_title}.pdf`;
+    } else {
+      filename = `${data.number}.pdf`;
+    }
     await convertHTMLToPDFAndDownload(htmlContentWithSections, filename);
   }
 
@@ -3599,9 +3606,16 @@ export const generatePDF = async (data: DocumentData) => {
     </html>
   `;
 
-  const fallbackFilename = data.project_title
-    ? `${data.number}-${data.project_title}.pdf`
-    : `${data.number}.pdf`;
+  let fallbackFilename: string;
+  if (data.type === 'receipt') {
+    fallbackFilename = `RECEIPT - ${data.number}.pdf`;
+  } else if (data.type === 'invoice' && data.project_title) {
+    fallbackFilename = `INVOICE - ${data.project_title}.pdf`;
+  } else if (data.project_title) {
+    fallbackFilename = `${data.number}-${data.project_title}.pdf`;
+  } else {
+    fallbackFilename = `${data.number}.pdf`;
+  }
   await convertHTMLToPDFAndDownload(htmlContent, fallbackFilename);
 };
 


### PR DESCRIPTION
### Summary
Adds a `display_as_percentage` boolean flag to quotations, proformas, and invoices to control how line item tax/discount values are rendered in PDFs. Also standardizes PDF file naming conventions for receipts and invoices.

### Problem
There was no way to mark a BOQ/Quotation/Proforma as "percentage-based" so that when converted to an invoice, the PDF could display calculated currency values instead of raw percentage columns. Additionally, when converting a proforma to an invoice, the conversion logic was a stub that only updated the proforma status without actually creating a real invoice record or copying items. PDF filenames also lacked a consistent, human-readable naming convention for receipts and invoices.

### Solution
Implemented the `display_as_percentage` flag at the document level and wired it through the full document lifecycle — from creation to conversion to PDF generation. The proforma-to-invoice conversion was fully implemented with proper item copying and stock movement tracking. PDF filenames are now generated based on document type.

### Key Changes
- **`useConvertProformaToInvoice` (useProforma.ts):** Replaced the stub conversion with a full implementation that fetches proforma data and items, creates a real invoice record (copying `display_as_percentage`), inserts invoice items, creates stock movements, and updates product stock quantities
- **`useConvertQuotationToInvoice` (useQuotationItems.ts):** Passes `display_as_percentage` from the source quotation to the newly created invoice
- **`CreateProformaModal.tsx`:** Initializes `display_as_percentage: false` in the form reset state
- **`pdfGenerator.ts`:**
  - Passes `display_as_percentage` flag into `DocumentData` for both invoice and quotation PDF downloads
  - Standardizes PDF filenames: receipts are named `RECEIPT - {number}.pdf`, invoices are named `INVOICE - {project_title}.pdf`, and other documents fall back to the existing `{number}-{project_title}.pdf` pattern


---

<a href="https://builder.io/app/projects/db3fbce863eb4ac9870798e5272f1568/ultra-volt-heuzuamg"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://db3fbce863eb4ac9870798e5272f1568-ultra-volt-heuzuamg_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 228`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>db3fbce863eb4ac9870798e5272f1568</projectId>-->
<!--<branchName>ultra-volt-heuzuamg</branchName>-->