### PR TITLE
Add autosave draft support for BOQ creation and editing

### DIFF
--- a/migrations/20250308_add_boq_id_to_drafts.sql
+++ b/migrations/20250308_add_boq_id_to_drafts.sql
@@ -1,0 +1,32 @@
+-- ============================================================================
+-- Migration: Add boq_id column to boq_drafts for edit-in-progress drafts
+-- ============================================================================
+-- This allows the table to store both:
+-- 1. Create drafts: boq_id IS NULL (new BOQ being created)
+-- 2. Edit drafts: boq_id IS NOT NULL (editing existing BOQ)
+-- 
+-- Unique constraint changes from (company_id, user_id) to (company_id, user_id, boq_id)
+-- This enables multiple drafts: one per user per company for create, plus one per BOQ being edited.
+
+BEGIN TRANSACTION;
+
+-- Add boq_id column (nullable, for edit-in-progress drafts)
+ALTER TABLE boq_drafts 
+ADD COLUMN IF NOT EXISTS boq_id UUID REFERENCES boqs(id) ON DELETE CASCADE;
+
+-- Drop the old UNIQUE constraint on (company_id, user_id)
+ALTER TABLE boq_drafts 
+DROP CONSTRAINT IF EXISTS boq_drafts_company_id_user_id_key;
+
+-- Create new UNIQUE constraint on (company_id, user_id, boq_id)
+-- This allows: one create draft (boq_id=NULL) + multiple edit drafts (boq_id=specific BOQ)
+ALTER TABLE boq_drafts 
+ADD CONSTRAINT boq_drafts_company_user_boq_unique UNIQUE(company_id, user_id, boq_id);
+
+-- Create index for efficient queries of edit drafts for a specific BOQ
+CREATE INDEX IF NOT EXISTS idx_boq_drafts_boq_id ON boq_drafts(boq_id);
+
+-- Update RLS policy to be explicit (no changes needed, but documenting intent)
+-- Users can only see and edit their own drafts (existing policies remain valid)
+
+COMMIT;

--- a/src/components/boq/BOQSaveIndicator.tsx
+++ b/src/components/boq/BOQSaveIndicator.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
+
+interface BOQSaveIndicatorProps {
+  isSaving: boolean;
+  lastSavedTime: string | null;
+  hasUnsavedChanges: boolean;
+}
+
+export function BOQSaveIndicator({
+  isSaving,
+  lastSavedTime,
+  hasUnsavedChanges,
+}: BOQSaveIndicatorProps) {
+  const [displayTime, setDisplayTime] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (lastSavedTime) {
+      const date = new Date(lastSavedTime);
+      const hours = String(date.getHours()).padStart(2, '0');
+      const minutes = String(date.getMinutes()).padStart(2, '0');
+      setDisplayTime(`${hours}:${minutes}`);
+    }
+  }, [lastSavedTime]);
+
+  if (isSaving) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span>Saving...</span>
+      </div>
+    );
+  }
+
+  if (hasUnsavedChanges) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-amber-600">
+        <AlertCircle className="h-4 w-4" />
+        <span>Unsaved changes</span>
+      </div>
+    );
+  }
+
+  if (displayTime) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-green-600">
+        <CheckCircle2 className="h-4 w-4" />
+        <span>Saved at {displayTime}</span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/boq/CreateBOQModal.tsx
+++ b/src/components/boq/CreateBOQModal.tsx
@@ -26,6 +26,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Plus, Trash2, Calculator, Layers, Check } from 'lucide-react';
 import { useCompanies, useCustomers, useUnits, useBOQs } from '@/hooks/useDatabase';
 import { CreateUnitModal } from '@/components/units/CreateUnitModal';
+import { BOQSaveIndicator } from '@/components/boq/BOQSaveIndicator';
 import { toast } from 'sonner';
 import { downloadBOQPDF, BoqDocument } from '@/utils/boqPdfGenerator';
 import { generateNextBOQNumber } from '@/utils/boqNumberGenerator';
@@ -812,10 +813,17 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
           </div>
         </div>
 
-        <DialogFooter className="mt-6 flex justify-between">
-          <Button variant="destructive" onClick={handleClearForm}>
-            Clear Form
-          </Button>
+        <DialogFooter className="mt-6 flex justify-between items-center">
+          <div className="flex items-center gap-4">
+            <Button variant="destructive" onClick={handleClearForm}>
+              Clear Form
+            </Button>
+            <BOQSaveIndicator
+              isSaving={draftSaved && lastAutosavedAt !== null}
+              lastSavedTime={lastAutosavedAt}
+              hasUnsavedChanges={false}
+            />
+          </div>
           <div className="space-x-2">
             <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
             <Button onClick={handleGenerate} disabled={submitting}>

--- a/src/components/boq/EditBOQModal.tsx
+++ b/src/components/boq/EditBOQModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -14,6 +14,16 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -25,10 +35,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Plus, Trash2, Calculator, Layers } from 'lucide-react';
 import { useCompanies, useCustomers, useUnits } from '@/hooks/useDatabase';
 import { CreateUnitModal } from '@/components/units/CreateUnitModal';
+import { BOQSaveIndicator } from '@/components/boq/BOQSaveIndicator';
 import { toast } from 'sonner';
 import { downloadBOQPDF, BoqDocument } from '@/utils/boqPdfGenerator';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { useDebounce } from '@/hooks/useDebounce';
+import { saveEditingDraft, loadEditDraft, deleteEditDraft } from '@/services/boqAutoSaveService';
 
 // Safe UUID generator that works in all environments
 const generateSafeUUID = (): string => {
@@ -102,6 +115,12 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
   const [unitModalOpen, setUnitModalOpen] = useState(false);
   const [pendingUnitTarget, setPendingUnitTarget] = useState<{ sectionId: string; itemId: string } | null>(null);
   const [previewItem, setPreviewItem] = useState<{ sectionId: string; subsectionId: string; itemId: string } | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSavedTime, setLastSavedTime] = useState<string | null>(null);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
+  const [pendingClose, setPendingClose] = useState(false);
+  const unsavedChangesRef = useRef(false);
 
   const [boqNumber, setBoqNumber] = useState('');
   const [boqDate, setBoqDate] = useState('');
@@ -118,63 +137,180 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
 
   const selectedClient = useMemo(() => customers.find(c => c.id === clientId), [customers, clientId]);
 
-  useEffect(() => {
-    if (open && boq && boq.data) {
-      const boqData = boq.data;
-      setBoqNumber(boq.number || '');
-      setBoqDate(boq.boq_date || '');
-      setDueDate(boq.due_date || '');
-      setProjectTitle(boqData.project_title || '');
-      setContractor(boqData.contractor || '');
-      setNotes(boqData.notes || '');
-      // Use ONLY top-level terms_and_conditions as source of truth (single source)
-      // Nested data should NOT be used for terms - top-level columns are authoritative
-      const termsToUse = boq.terms_and_conditions || '';
-      setTermsAndConditions(termsToUse);
-      // Use ONLY top-level showCalculatedValuesInTerms as source of truth
-      const showCalcValues = boq.showCalculatedValuesInTerms || false;
-      setShowCalculatedValuesInTerms(showCalcValues);
-      setCurrency(boqData.currency || 'KES');
+  // Autosave function
+  const performAutosave = useCallback(async () => {
+    if (!boq?.id || !profile?.id || !currentCompany?.id) return;
 
-      const clientIdFromBoq = customers.find(c => c.name === boq.client_name)?.id;
-      if (clientIdFromBoq) {
-        setClientId(clientIdFromBoq);
-      }
+    setIsSaving(true);
+    try {
+      const filledSections = getFilledItems();
 
-      if (boqData.sections && boqData.sections.length > 0) {
-        const loadedSections: BOQSectionRow[] = boqData.sections.map((section: any) => ({
-          id: `section-${generateSafeUUID()}`,
-          title: section.title || 'General',
-          subsections: (section.subsections || []).map((subsection: any) => ({
-            id: `subsection-${generateSafeUUID()}`,
-            name: subsection.name,
-            label: subsection.label,
-            items: (subsection.items || []).map((item: any) => ({
-              id: `item-${generateSafeUUID()}`,
-              description: item.description,
-              quantity: item.quantity || 1,
-              unit: item.unit_id || '',
-              rate: item.rate || 0,
-            })),
+      let filledSubtotal = 0;
+      filledSections.forEach(sec => {
+        sec.subsections.forEach(sub => {
+          sub.items.forEach(item => {
+            filledSubtotal += (item.quantity || 0) * (item.rate || 0);
+          });
+        });
+      });
+
+      const draftData = {
+        number: boqNumber,
+        boq_date: boqDate,
+        due_date: dueDate,
+        customer_id: clientId,
+        client_name: selectedClient?.name || '',
+        client_email: selectedClient?.email || null,
+        client_phone: selectedClient?.phone || null,
+        client_address: selectedClient?.address || null,
+        client_city: selectedClient?.city || null,
+        client_country: selectedClient?.country || null,
+        contractor: contractor || null,
+        project_title: projectTitle || null,
+        currency: currency,
+        subtotal: filledSubtotal,
+        tax_amount: 0,
+        total_amount: filledSubtotal,
+        data: {
+          sections: filledSections.map(s => ({
+            title: s.title,
+            subsections: s.subsections.map(sub => ({
+              name: sub.name,
+              label: sub.label,
+              items: sub.items.map(i => {
+                const unitObj = units.find((u: any) => u.id === i.unit);
+                return {
+                  description: i.description,
+                  quantity: i.quantity,
+                  unit_id: i.unit || null,
+                  unit_name: unitObj ? unitObj.name : i.unit || null,
+                  rate: i.rate,
+                };
+              })
+            }))
           })),
-        }));
-        setSections(loadedSections);
+          notes: notes,
+        },
+        terms_and_conditions: termsAndConditions || null,
+        show_calculated_values_in_terms: showCalculatedValuesInTerms,
+      };
+
+      const result = await saveEditingDraft(profile.id, currentCompany.id, boq.id, draftData);
+
+      if (result.success) {
+        setLastSavedTime(new Date().toISOString());
+        setHasUnsavedChanges(false);
+        unsavedChangesRef.current = false;
       } else {
-        setSections([defaultSection()]);
+        console.error('Autosave failed:', result.error);
       }
+    } catch (err) {
+      console.error('Error during autosave:', err);
+    } finally {
+      setIsSaving(false);
     }
-  }, [open, boq, customers]);
+  }, [boq?.id, profile?.id, currentCompany?.id, boqNumber, boqDate, dueDate, clientId, selectedClient, contractor, projectTitle, currency, units, notes, termsAndConditions, showCalculatedValuesInTerms]);
+
+  // Debounce autosave to 5 seconds
+  const debouncedAutosave = useDebounce(performAutosave, 5000);
+
+  // Mark as changed and trigger autosave
+  const triggerAutosave = useCallback(() => {
+    setHasUnsavedChanges(true);
+    unsavedChangesRef.current = true;
+    debouncedAutosave();
+  }, [debouncedAutosave]);
+
+  // Handle browser unload with unsaved changes
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (unsavedChangesRef.current) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
+
+  useEffect(() => {
+    if (open && boq && boq.data && profile?.id && currentCompany?.id) {
+      // Check if there's an edit draft for this BOQ
+      const checkAndLoadDraft = async () => {
+        const editDraft = await loadEditDraft(profile.id, currentCompany.id, boq.id);
+
+        // Load from draft if it exists and is newer than published version
+        const dataToUse = editDraft && new Date(editDraft.updated_at) > new Date(boq.updated_at)
+          ? editDraft
+          : boq;
+
+        const boqData = dataToUse.data;
+        setBoqNumber(dataToUse.number || '');
+        setBoqDate(dataToUse.boq_date || '');
+        setDueDate(dataToUse.due_date || '');
+        setProjectTitle(boqData.project_title || '');
+        setContractor(boqData.contractor || '');
+        setNotes(boqData.notes || '');
+
+        const termsToUse = dataToUse.terms_and_conditions || '';
+        setTermsAndConditions(termsToUse);
+        const showCalcValues = dataToUse.show_calculated_values_in_terms || false;
+        setShowCalculatedValuesInTerms(showCalcValues);
+        setCurrency(boqData.currency || 'KES');
+
+        const clientIdFromBoq = customers.find(c => c.name === dataToUse.client_name)?.id;
+        if (clientIdFromBoq) {
+          setClientId(clientIdFromBoq);
+        }
+
+        if (boqData.sections && boqData.sections.length > 0) {
+          const loadedSections: BOQSectionRow[] = boqData.sections.map((section: any) => ({
+            id: `section-${generateSafeUUID()}`,
+            title: section.title || 'General',
+            subsections: (section.subsections || []).map((subsection: any) => ({
+              id: `subsection-${generateSafeUUID()}`,
+              name: subsection.name,
+              label: subsection.label,
+              items: (subsection.items || []).map((item: any) => ({
+                id: `item-${generateSafeUUID()}`,
+                description: item.description,
+                quantity: item.quantity || 1,
+                unit: item.unit_id || '',
+                rate: item.rate || 0,
+              })),
+            })),
+          }));
+          setSections(loadedSections);
+        } else {
+          setSections([defaultSection()]);
+        }
+
+        // Set last saved time if we loaded a draft
+        if (editDraft) {
+          setLastSavedTime(editDraft.last_autosaved_at);
+        }
+        setHasUnsavedChanges(false);
+        unsavedChangesRef.current = false;
+      };
+
+      checkAndLoadDraft();
+    }
+  }, [open, boq, customers, profile?.id, currentCompany?.id]);
 
   const addSection = () => {
     setSections(prev => [...prev, defaultSection()]);
+    triggerAutosave();
   };
 
   const removeSection = (sectionId: string) => {
     setSections(prev => prev.filter(s => s.id !== sectionId));
+    triggerAutosave();
   };
 
   const updateSectionTitle = (sectionId: string, title: string) => {
     setSections(prev => prev.map(s => s.id === sectionId ? { ...s, title } : s));
+    triggerAutosave();
   };
 
   const addItem = (sectionId: string, subsectionId: string) => {
@@ -182,6 +318,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
       ...s,
       subsections: s.subsections.map(sub => sub.id === subsectionId ? { ...sub, items: [...sub.items, defaultItem()] } : sub)
     } : s));
+    triggerAutosave();
   };
 
   const removeItem = (sectionId: string, subsectionId: string, itemId: string) => {
@@ -189,6 +326,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
       ...s,
       subsections: s.subsections.map(sub => sub.id === subsectionId ? { ...sub, items: sub.items.filter(i => i.id !== itemId) } : sub)
     } : s));
+    triggerAutosave();
   };
 
   const updateItem = (sectionId: string, subsectionId: string, itemId: string, field: keyof BOQItemRow, value: string | number) => {
@@ -205,6 +343,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         })
       };
     }));
+    triggerAutosave();
   };
 
   const updateSubsectionLabel = (sectionId: string, subsectionId: string, label: string) => {
@@ -212,6 +351,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
       ...s,
       subsections: s.subsections.map(sub => sub.id === subsectionId ? { ...sub, label } : sub)
     } : s));
+    triggerAutosave();
   };
 
   const addSubsection = (sectionId: string) => {
@@ -223,6 +363,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         subsections: [...s.subsections, defaultSubsection(nextLetter, `Subsection ${nextLetter}`)]
       };
     }));
+    triggerAutosave();
   };
 
   const removeSubsection = (sectionId: string, subsectionId: string) => {
@@ -233,6 +374,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         subsections: s.subsections.filter(sub => sub.id !== subsectionId)
       };
     }));
+    triggerAutosave();
   };
 
   const formatCurrency = (amount: number) => {
@@ -379,6 +521,13 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         return;
       }
 
+      // Delete the edit draft since we've successfully saved
+      if (profile?.id && currentCompany?.id) {
+        await deleteEditDraft(profile.id, currentCompany.id, boq.id);
+      }
+
+      setHasUnsavedChanges(false);
+      unsavedChangesRef.current = false;
       toast.success(`BOQ ${boqNumber} updated`);
       onOpenChange(false);
       onSuccess?.();
@@ -407,19 +556,19 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div>
               <Label>BOQ Number</Label>
-              <Input value={boqNumber} onChange={e => setBoqNumber(e.target.value)} />
+              <Input value={boqNumber} onChange={e => { setBoqNumber(e.target.value); triggerAutosave(); }} />
             </div>
             <div>
               <Label>Date</Label>
-              <Input type="date" value={boqDate} onChange={e => setBoqDate(e.target.value)} />
+              <Input type="date" value={boqDate} onChange={e => { setBoqDate(e.target.value); triggerAutosave(); }} />
             </div>
             <div>
               <Label>Due Date</Label>
-              <Input type="date" value={dueDate} onChange={e => setDueDate(e.target.value)} />
+              <Input type="date" value={dueDate} onChange={e => { setDueDate(e.target.value); triggerAutosave(); }} />
             </div>
             <div>
               <Label>Currency</Label>
-              <Select value={currency} onValueChange={setCurrency}>
+              <Select value={currency} onValueChange={val => { setCurrency(val); triggerAutosave(); }}>
                 <SelectTrigger>
                   <SelectValue placeholder="Select currency" />
                 </SelectTrigger>
@@ -435,7 +584,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
 
           <div>
             <Label>Client</Label>
-            <Select value={clientId} onValueChange={setClientId}>
+            <Select value={clientId} onValueChange={val => { setClientId(val); triggerAutosave(); }}>
               <SelectTrigger>
                 <SelectValue placeholder="Select client" />
               </SelectTrigger>
@@ -450,11 +599,11 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <Label>Project Title</Label>
-              <Input value={projectTitle} onChange={e => setProjectTitle(e.target.value)} />
+              <Input value={projectTitle} onChange={e => { setProjectTitle(e.target.value); triggerAutosave(); }} />
             </div>
             <div>
               <Label>Contractor</Label>
-              <Input value={contractor} onChange={e => setContractor(e.target.value)} />
+              <Input value={contractor} onChange={e => { setContractor(e.target.value); triggerAutosave(); }} />
             </div>
           </div>
 
@@ -611,21 +760,21 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
 
           <div>
             <Label>Notes</Label>
-            <Textarea value={notes} onChange={e => setNotes(e.target.value)} rows={4} placeholder="Any special notes or terms" />
+            <Textarea value={notes} onChange={e => { setNotes(e.target.value); triggerAutosave(); }} rows={4} placeholder="Any special notes or terms" />
           </div>
 
           <div>
             <Label>Terms and Conditions</Label>
             <Textarea
               value={termsAndConditions}
-              onChange={e => setTermsAndConditions(e.target.value)}
+              onChange={e => { setTermsAndConditions(e.target.value); triggerAutosave(); }}
               rows={6}
             />
             <div className="flex items-center space-x-2 mt-3">
               <Checkbox
                 id="showCalculatedValues"
                 checked={showCalculatedValuesInTerms}
-                onCheckedChange={(checked) => setShowCalculatedValuesInTerms(checked === true)}
+                onCheckedChange={(checked) => { setShowCalculatedValuesInTerms(checked === true); triggerAutosave(); }}
               />
               <Label htmlFor="showCalculatedValues" className="font-normal cursor-pointer">
                 Show calculated values (e.g., 50% (KES 50,000))
@@ -634,13 +783,46 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
           </div>
         </div>
 
-        <DialogFooter className="mt-6">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
-          <Button onClick={handleSave} disabled={submitting}>
-            <Calculator className="h-4 w-4 mr-2" />
-            {submitting ? 'Saving...' : 'Save Changes'}
-          </Button>
+        <DialogFooter className="mt-6 flex items-center justify-between">
+          <BOQSaveIndicator
+            isSaving={isSaving}
+            lastSavedTime={lastSavedTime}
+            hasUnsavedChanges={hasUnsavedChanges}
+          />
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => {
+              if (unsavedChangesRef.current) {
+                setShowUnsavedDialog(true);
+              } else {
+                onOpenChange(false);
+              }
+            }}>Cancel</Button>
+            <Button onClick={handleSave} disabled={submitting}>
+              <Calculator className="h-4 w-4 mr-2" />
+              {submitting ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </div>
         </DialogFooter>
+
+        <AlertDialog open={showUnsavedDialog} onOpenChange={setShowUnsavedDialog}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
+              <AlertDialogDescription>
+                You have unsaved changes. Are you sure you want to close without saving?
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Keep Editing</AlertDialogCancel>
+              <AlertDialogAction onClick={() => {
+                setShowUnsavedDialog(false);
+                onOpenChange(false);
+              }}>
+                Discard Changes
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </DialogContent>
     </Dialog>
   );

--- a/src/services/boqAutoSaveService.ts
+++ b/src/services/boqAutoSaveService.ts
@@ -54,7 +54,7 @@ export interface BOQDraftRecord {
 /**
  * Save or update a BOQ draft to the database.
  * Uses upsert logic (update if exists, insert if new).
- * Only one draft per user per company is allowed.
+ * Only one draft per user per company is allowed (for creating new BOQs).
  */
 export async function saveBoqDraft(
   userId: string,
@@ -70,6 +70,7 @@ export async function saveBoqDraft(
     const payload = {
       company_id: companyId,
       user_id: userId,
+      boq_id: null,
       number: formData.boqNumber || null,
       boq_date: formData.boqDate || null,
       due_date: formData.dueDate || null,
@@ -96,11 +97,11 @@ export async function saveBoqDraft(
       last_autosaved_at: new Date().toISOString(),
     };
 
-    // Use upsert: on conflict (company_id, user_id), update the existing draft
+    // Use upsert: on conflict (company_id, user_id, boq_id), update the existing draft
     const { data, error } = await supabase
       .from('boq_drafts')
       .upsert([payload], {
-        onConflict: 'company_id,user_id',
+        onConflict: 'company_id,user_id,boq_id',
       })
       .select('id')
       .single();
@@ -271,8 +272,146 @@ export async function publishDraft(
 }
 
 /**
+ * Save a draft for an existing BOQ being edited.
+ * This creates/updates an edit-in-progress draft with boq_id set.
+ * Allows one edit draft per BOQ per user.
+ */
+export async function saveEditingDraft(
+  userId: string,
+  companyId: string,
+  boqId: string,
+  boqData: any
+): Promise<{ success: boolean; error?: string; draftId?: string }> {
+  try {
+    if (!userId || !companyId || !boqId) {
+      return { success: false, error: 'User ID, Company ID, and BOQ ID are required' };
+    }
+
+    const payload = {
+      company_id: companyId,
+      user_id: userId,
+      boq_id: boqId,
+      number: boqData.number || null,
+      boq_date: boqData.boq_date || null,
+      due_date: boqData.due_date || null,
+      customer_id: boqData.customer_id || null,
+      client_name: boqData.client_name || null,
+      client_email: boqData.client_email || null,
+      client_phone: boqData.client_phone || null,
+      client_address: boqData.client_address || null,
+      client_city: boqData.client_city || null,
+      client_country: boqData.client_country || null,
+      contractor: boqData.contractor || null,
+      project_title: boqData.project_title || null,
+      currency: boqData.currency || 'KES',
+      subtotal: boqData.subtotal || 0,
+      tax_amount: boqData.tax_amount || 0,
+      total_amount: boqData.total_amount || 0,
+      data: boqData.data,
+      terms_and_conditions: boqData.terms_and_conditions || null,
+      show_calculated_values_in_terms: boqData.show_calculated_values_in_terms || false,
+      updated_at: new Date().toISOString(),
+      last_autosaved_at: new Date().toISOString(),
+    };
+
+    // Use upsert: on conflict (company_id, user_id, boq_id), update the existing edit draft
+    const { data, error } = await supabase
+      .from('boq_drafts')
+      .upsert([payload], {
+        onConflict: 'company_id,user_id,boq_id',
+      })
+      .select('id')
+      .single();
+
+    if (error) {
+      console.error('Failed to save editing draft:', error);
+      return { success: false, error: error.message };
+    }
+
+    return { success: true, draftId: data?.id };
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+    console.error('Error saving editing draft:', errorMsg);
+    return { success: false, error: errorMsg };
+  }
+}
+
+/**
+ * Load an edit draft for a specific BOQ.
+ * Returns null if no draft exists.
+ */
+export async function loadEditDraft(
+  userId: string,
+  companyId: string,
+  boqId: string
+): Promise<BOQDraftRecord | null> {
+  try {
+    if (!userId || !companyId || !boqId) {
+      return null;
+    }
+
+    const { data, error } = await supabase
+      .from('boq_drafts')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('company_id', companyId)
+      .eq('boq_id', boqId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        // No rows found - expected when no draft exists
+        return null;
+      }
+      console.error('Failed to load edit draft:', error);
+      return null;
+    }
+
+    return data as BOQDraftRecord;
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+    console.error('Error loading edit draft:', errorMsg);
+    return null;
+  }
+}
+
+/**
+ * Delete an edit draft for a specific BOQ.
+ * Called after successful save to clean up.
+ */
+export async function deleteEditDraft(
+  userId: string,
+  companyId: string,
+  boqId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    if (!userId || !companyId || !boqId) {
+      return { success: false, error: 'User ID, Company ID, and BOQ ID are required' };
+    }
+
+    const { error } = await supabase
+      .from('boq_drafts')
+      .delete()
+      .eq('user_id', userId)
+      .eq('company_id', companyId)
+      .eq('boq_id', boqId);
+
+    if (error) {
+      console.error('Failed to delete edit draft:', error);
+      return { success: false, error: error.message };
+    }
+
+    return { success: true };
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+    console.error('Error deleting edit draft:', errorMsg);
+    return { success: false, error: errorMsg };
+  }
+}
+
+/**
  * Check if a user has an unsaved draft for a company.
- * Returns true if draft exists.
+ * Returns true if draft exists (checks only create drafts with boq_id=NULL).
  */
 export async function hasDraft(
   userId: string,
@@ -283,7 +422,8 @@ export async function hasDraft(
       .from('boq_drafts')
       .select('id', { count: 'exact' })
       .eq('user_id', userId)
-      .eq('company_id', companyId);
+      .eq('company_id', companyId)
+      .is('boq_id', null);
 
     if (error) {
       console.error('Failed to check for draft:', error);


### PR DESCRIPTION
### Summary
Adds autosave (save-in-progress) functionality to both the BOQ creation and editing workflows, ensuring users do not lose data when working on large BOQs.

### Problem
When creating or editing a large BOQ, users risked losing all their work if the modal was closed accidentally or the session was interrupted. There was no mechanism to persist in-progress changes automatically.

### Solution
Implemented an autosave draft system that periodically saves BOQ form state to the database. For editing existing BOQs, a new `boq_id` column on the `boq_drafts` table allows storing edit drafts separately from create drafts. A visual save indicator keeps users informed of the save status, and an unsaved-changes dialog warns users before discarding edits.

### Key Changes
- **Migration** (`20250308_add_boq_id_to_drafts.sql`): Adds a nullable `boq_id` column to `boq_drafts`, updates the unique constraint from `(company_id, user_id)` to `(company_id, user_id, boq_id)`, and adds an index for efficient edit-draft queries.
- **`BOQSaveIndicator` component**: New UI component that displays saving state (spinner), unsaved changes warning (amber), or last saved time (green checkmark).
- **`boqAutoSaveService`**: Added `saveEditingDraft`, `loadEditDraft`, and `deleteEditDraft` functions to manage per-BOQ edit drafts; updated `saveBoqDraft` and `hasDraft` to explicitly handle `boq_id = null` for create drafts.
- **`EditBOQModal`**: Integrated debounced autosave on all form field changes, draft loading on open, draft cleanup on successful save, and an `AlertDialog` to warn users of unsaved changes on cancel.
- **`CreateBOQModal`**: Integrated the `BOQSaveIndicator` to display autosave status in the footer.


---

<a href="https://builder.io/app/projects/8268c35e7370460bbb90/royal-tempo-jpumkcym"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://8268c35e7370460bbb90-royal-tempo-jpumkcym_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=8268c35e7370460bbb90&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 230`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8268c35e7370460bbb90</projectId>-->
<!--<branchName>royal-tempo-jpumkcym</branchName>-->