### PR TITLE
Implement BOQ auto-save with stable refs and draft uniqueness

### DIFF
--- a/src/components/boq/CreateBOQModal.tsx
+++ b/src/components/boq/CreateBOQModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useRef } from 'react';
+import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -111,10 +111,12 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
   const [lastAutosavedAt, setLastAutosavedAt] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [draftLoaded, setDraftLoaded] = useState(false);
+  const [authReadyError, setAuthReadyError] = useState<string | null>(null);
 
   const pendingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const pendingFormDataRef = useRef<any>(null);
   const lastProfileRef = useRef(profile);
+  const formStateRef = useRef<any>({});
 
   const todayISO = new Date().toISOString().split('T')[0];
   const defaultNumber = useMemo(() => {
@@ -207,13 +209,16 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
   // Autosave implementation with flush capability
   const performAutosave = async (formData: any) => {
     if (!currentCompany?.id || !profile?.id) {
-      console.warn('[CreateBOQModal] Autosave aborted: missing company or profile ID', { companyId: currentCompany?.id, profileId: profile?.id });
+      const reason = !currentCompany?.id ? 'Company not loaded yet' : 'Auth not ready yet';
+      console.warn('[CreateBOQModal] Autosave deferred: ' + reason, { companyId: currentCompany?.id, profileId: profile?.id });
+      setAuthReadyError(reason);
       return;
     }
 
     try {
       setIsSavingDraft(true);
       setSaveError(null);
+      setAuthReadyError(null);
       const selectedCustomer = customers.find(c => c.id === formData.clientId);
       const result = await saveBoqDraft(profile.id, currentCompany.id, {
         boqNumber: formData.boqNumber,
@@ -251,67 +256,53 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
     }
   };
 
-  // Create debounced autosave function with manual flush capability
-  const debouncedAutoSave = (formData: any) => {
-    pendingFormDataRef.current = formData;
-
+  // Create debounced autosave function with manual flush capability (memoized for stability)
+  const debouncedAutoSave = useCallback(() => {
     if (pendingTimeoutRef.current) {
       clearTimeout(pendingTimeoutRef.current);
     }
 
     pendingTimeoutRef.current = setTimeout(() => {
-      if (pendingFormDataRef.current) {
-        performAutosave(pendingFormDataRef.current);
-        pendingFormDataRef.current = null;
+      if (formStateRef.current) {
+        performAutosave(formStateRef.current);
       }
     }, 5000);
-  };
+  }, [performAutosave]);
 
   // Flush pending autosave when modal closes
-  const flushPendingAutosave = async () => {
+  const flushPendingAutosave = useCallback(async () => {
     if (pendingTimeoutRef.current) {
       clearTimeout(pendingTimeoutRef.current);
       pendingTimeoutRef.current = null;
     }
-    if (pendingFormDataRef.current) {
-      await performAutosave(pendingFormDataRef.current);
-      pendingFormDataRef.current = null;
+    if (formStateRef.current && Object.keys(formStateRef.current).length > 0) {
+      await performAutosave(formStateRef.current);
     }
-  };
+  }, [performAutosave]);
 
-  // Autosave whenever form state changes
+  // Sync form state to ref whenever it changes
   useEffect(() => {
-    if (open) {
-      const formData = {
-        boqNumber,
-        boqDate,
-        dueDate,
-        clientId,
-        projectTitle,
-        contractor,
-        notes,
-        termsAndConditions,
-        showCalculatedValuesInTerms,
-        currency,
-        sections,
-      };
-      debouncedAutoSave(formData);
+    formStateRef.current = {
+      boqNumber,
+      boqDate,
+      dueDate,
+      clientId,
+      projectTitle,
+      contractor,
+      notes,
+      termsAndConditions,
+      showCalculatedValuesInTerms,
+      currency,
+      sections,
+    };
+  }, [boqNumber, boqDate, dueDate, clientId, projectTitle, contractor, notes, termsAndConditions, showCalculatedValuesInTerms, currency, sections]);
+
+  // Autosave whenever form state changes (only depends on open and debouncedAutoSave)
+  useEffect(() => {
+    if (open && Object.keys(formStateRef.current).length > 0) {
+      debouncedAutoSave();
     }
-  }, [
-    open,
-    boqNumber,
-    boqDate,
-    dueDate,
-    clientId,
-    projectTitle,
-    contractor,
-    notes,
-    termsAndConditions,
-    showCalculatedValuesInTerms,
-    currency,
-    sections,
-    debouncedAutoSave,
-  ]);
+  }, [open, debouncedAutoSave]);
 
   const selectedClient = useMemo(() => customers.find(c => c.id === clientId), [customers, clientId]);
 

--- a/src/components/boq/EditBOQModal.tsx
+++ b/src/components/boq/EditBOQModal.tsx
@@ -120,7 +120,9 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [pendingClose, setPendingClose] = useState(false);
+  const [editSaveError, setEditSaveError] = useState<string | null>(null);
   const unsavedChangesRef = useRef(false);
+  const pendingChangesRef = useRef<any>({});
 
   const [boqNumber, setBoqNumber] = useState('');
   const [boqDate, setBoqDate] = useState('');
@@ -137,48 +139,60 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
 
   const selectedClient = useMemo(() => customers.find(c => c.id === clientId), [customers, clientId]);
 
-  // Autosave function
+  // Autosave function - uses fresh data from pendingChangesRef
   const performAutosave = useCallback(async () => {
     if (!boq?.id || !profile?.id || !currentCompany?.id) return;
 
     setIsSaving(true);
+    setEditSaveError(null);
     try {
-      const filledSections = getFilledItems();
+      const changes = pendingChangesRef.current;
+
+      // Build filled sections from the ref data
+      const filledSections = (changes.sections || []).map((s: any) => ({
+        ...s,
+        subsections: (s.subsections || []).map((sub: any) => ({
+          ...sub,
+          items: (sub.items || []).filter((i: any) => {
+            return i.description.trim() || (i.quantity && Number(i.quantity) > 0) || (i.rate && Number(i.rate) > 0);
+          })
+        }))
+      }));
 
       let filledSubtotal = 0;
-      filledSections.forEach(sec => {
-        sec.subsections.forEach(sub => {
-          sub.items.forEach(item => {
+      filledSections.forEach((sec: any) => {
+        sec.subsections.forEach((sub: any) => {
+          sub.items.forEach((item: any) => {
             filledSubtotal += (item.quantity || 0) * (item.rate || 0);
           });
         });
       });
 
       const draftData = {
-        number: boqNumber,
-        boq_date: boqDate,
-        due_date: dueDate,
-        customer_id: clientId,
-        client_name: selectedClient?.name || '',
-        client_email: selectedClient?.email || null,
-        client_phone: selectedClient?.phone || null,
-        client_address: selectedClient?.address || null,
-        client_city: selectedClient?.city || null,
-        client_country: selectedClient?.country || null,
-        contractor: contractor || null,
-        project_title: projectTitle || null,
-        currency: currency,
+        number: changes.boqNumber,
+        boq_date: changes.boqDate,
+        due_date: changes.dueDate,
+        customer_id: changes.clientId,
+        client_name: changes.selectedClientName || '',
+        client_email: changes.selectedClientEmail || null,
+        client_phone: changes.selectedClientPhone || null,
+        client_address: changes.selectedClientAddress || null,
+        client_city: changes.selectedClientCity || null,
+        client_country: changes.selectedClientCountry || null,
+        contractor: changes.contractor || null,
+        project_title: changes.projectTitle || null,
+        currency: changes.currency,
         subtotal: filledSubtotal,
         tax_amount: 0,
         total_amount: filledSubtotal,
         data: {
-          sections: filledSections.map(s => ({
+          sections: filledSections.map((s: any) => ({
             title: s.title,
-            subsections: s.subsections.map(sub => ({
+            subsections: s.subsections.map((sub: any) => ({
               name: sub.name,
               label: sub.label,
-              items: sub.items.map(i => {
-                const unitObj = units.find((u: any) => u.id === i.unit);
+              items: sub.items.map((i: any) => {
+                const unitObj = changes.units.find((u: any) => u.id === i.unit);
                 return {
                   description: i.description,
                   quantity: i.quantity,
@@ -189,10 +203,10 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
               })
             }))
           })),
-          notes: notes,
+          notes: changes.notes,
         },
-        terms_and_conditions: termsAndConditions || null,
-        show_calculated_values_in_terms: showCalculatedValuesInTerms,
+        terms_and_conditions: changes.termsAndConditions || null,
+        show_calculated_values_in_terms: changes.showCalculatedValuesInTerms,
       };
 
       const result = await saveEditingDraft(profile.id, currentCompany.id, boq.id, draftData);
@@ -201,15 +215,43 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         setLastSavedTime(new Date().toISOString());
         setHasUnsavedChanges(false);
         unsavedChangesRef.current = false;
+        setEditSaveError(null);
       } else {
         console.error('Autosave failed:', result.error);
+        setEditSaveError(result.error || 'Failed to save draft');
       }
     } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Unknown error';
       console.error('Error during autosave:', err);
+      setEditSaveError(errorMsg);
     } finally {
       setIsSaving(false);
     }
-  }, [boq?.id, profile?.id, currentCompany?.id, boqNumber, boqDate, dueDate, clientId, selectedClient, contractor, projectTitle, currency, units, notes, termsAndConditions, showCalculatedValuesInTerms]);
+  }, [boq?.id, profile?.id, currentCompany?.id]);
+
+  // Keep pendingChangesRef in sync with all form state
+  useEffect(() => {
+    pendingChangesRef.current = {
+      boqNumber,
+      boqDate,
+      dueDate,
+      clientId,
+      selectedClientName: selectedClient?.name,
+      selectedClientEmail: selectedClient?.email,
+      selectedClientPhone: selectedClient?.phone,
+      selectedClientAddress: selectedClient?.address,
+      selectedClientCity: selectedClient?.city,
+      selectedClientCountry: selectedClient?.country,
+      contractor,
+      projectTitle,
+      currency,
+      units,
+      notes,
+      termsAndConditions,
+      showCalculatedValuesInTerms,
+      sections,
+    };
+  }, [boqNumber, boqDate, dueDate, clientId, selectedClient, contractor, projectTitle, currency, units, notes, termsAndConditions, showCalculatedValuesInTerms, sections]);
 
   // Debounce autosave to 5 seconds
   const debouncedAutosave = useDebounce(performAutosave, 5000);
@@ -796,6 +838,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
             isSaving={isSaving}
             lastSavedTime={lastSavedTime}
             hasUnsavedChanges={hasUnsavedChanges}
+            saveError={editSaveError}
           />
           <div className="flex gap-2">
             <Button variant="outline" onClick={() => {

--- a/supabase/migrations/20260522115011_add_partial_unique_index_create_drafts.sql
+++ b/supabase/migrations/20260522115011_add_partial_unique_index_create_drafts.sql
@@ -1,0 +1,11 @@
+-- Fix CREATE draft uniqueness by adding a partial unique index
+-- This ensures only one create draft (boq_id IS NULL) exists per user/company
+-- Edit drafts (boq_id IS NOT NULL) are unaffected by this constraint
+
+CREATE UNIQUE INDEX idx_boq_drafts_create_draft_unique 
+ON boq_drafts (company_id, user_id) 
+WHERE boq_id IS NULL;
+
+-- Add a comment explaining the purpose
+COMMENT ON INDEX idx_boq_drafts_create_draft_unique IS 
+'Enforces exactly one create draft per user per company. Only applies when boq_id IS NULL.';


### PR DESCRIPTION
### Summary
This PR implements a stable and reliable auto-save (draft) mechanism for both the Create and Edit BOQ modals, ensuring form state is continuously persisted without triggering unnecessary re-renders or stale closure issues.

### Problem
The BOQ modals lacked a robust auto-save system. The previous implementation passed form data directly into debounced functions, causing stale closure bugs where outdated state could be saved. Additionally, there was no uniqueness constraint on create drafts, allowing duplicate draft records per user/company.

### Solution
Form state is now synced to a `ref` on every change, and the debounced auto-save reads from that ref at execution time — ensuring it always uses the latest data. A partial unique index was added to the database to enforce a single create draft per user per company.

### Key Changes
- **`CreateBOQModal`**: Introduced `formStateRef` to hold the latest form state; `debouncedAutoSave` is memoized with `useCallback` and reads from the ref instead of receiving data as an argument; separated the form-sync effect from the autosave trigger effect for clarity; added `authReadyError` state to surface deferred-save reasons to the UI.
- **`EditBOQModal`**: Introduced `pendingChangesRef` to hold all form field values; refactored `performAutosave` to read from the ref, removing all form state from its `useCallback` dependency array (now only depends on stable IDs); added `editSaveError` state and wired it to the save status component; builds filled sections directly from ref data instead of calling `getFilledItems()`.
- **Database migration**: Added a partial unique index `idx_boq_drafts_create_draft_unique` on `boq_drafts (company_id, user_id) WHERE boq_id IS NULL` to enforce exactly one create draft per user per company.


---

<a href="https://builder.io/app/projects/22472e7cb29a43c6825f/burgundy-fountain-o5yys5iy"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://22472e7cb29a43c6825f-burgundy-fountain-o5yys5iy_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=22472e7cb29a43c6825f&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 234`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>22472e7cb29a43c6825f</projectId>-->
<!--<branchName>burgundy-fountain-o5yys5iy</branchName>-->