### PR TITLE
Fix BOQ autosave indicator showing pending save state

### DIFF
--- a/src/components/boq/BOQSaveIndicator.tsx
+++ b/src/components/boq/BOQSaveIndicator.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Loader2, CheckCircle2, AlertCircle, Clock } from 'lucide-react';
 
 interface BOQSaveIndicatorProps {
   isSaving: boolean;
@@ -14,11 +14,26 @@ export function BOQSaveIndicator({
   hasUnsavedChanges,
   saveError,
 }: BOQSaveIndicatorProps) {
+  const [showSavingIndicator, setShowSavingIndicator] = useState(false);
+
+  useEffect(() => {
+    if (hasUnsavedChanges && !isSaving && !saveError) {
+      // Wait 1 second before showing "Autosaving in progress..." to avoid flicker
+      // (the 5-second debounce timer is counting down)
+      const timer = setTimeout(() => {
+        setShowSavingIndicator(true);
+      }, 1000);
+      return () => clearTimeout(timer);
+    } else {
+      setShowSavingIndicator(false);
+    }
+  }, [hasUnsavedChanges, isSaving, saveError]);
+
   if (saveError) {
     return (
       <div className="flex items-center gap-2 text-sm text-red-600">
         <AlertCircle className="h-4 w-4" />
-        <span title={saveError}>Save failed</span>
+        <span title={saveError}>Save failed — will retry</span>
       </div>
     );
   }
@@ -27,7 +42,16 @@ export function BOQSaveIndicator({
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin" />
-        <span>Saving...</span>
+        <span>Saving draft...</span>
+      </div>
+    );
+  }
+
+  if (hasUnsavedChanges && showSavingIndicator) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-blue-600">
+        <Clock className="h-4 w-4" />
+        <span>Autosaving in progress...</span>
       </div>
     );
   }

--- a/src/components/boq/CreateBOQModal.tsx
+++ b/src/components/boq/CreateBOQModal.tsx
@@ -297,28 +297,34 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
     };
   }, [boqNumber, boqDate, dueDate, clientId, projectTitle, contractor, notes, termsAndConditions, showCalculatedValuesInTerms, currency, sections]);
 
-  // Autosave whenever form state changes (only depends on open and debouncedAutoSave)
+  // Autosave whenever form state changes
   useEffect(() => {
     if (open && Object.keys(formStateRef.current).length > 0) {
       debouncedAutoSave();
     }
-  }, [open, debouncedAutoSave]);
+  }, [open, boqNumber, boqDate, dueDate, clientId, projectTitle, contractor, notes, termsAndConditions, showCalculatedValuesInTerms, currency, sections, debouncedAutoSave]);
+
+  // Helper to mark changes and clear any previous errors for auto-retry
+  const markChanged = useCallback(() => {
+    setHasUnsavedChanges(true);
+    if (saveError) setSaveError(null);
+  }, [saveError]);
 
   const selectedClient = useMemo(() => customers.find(c => c.id === clientId), [customers, clientId]);
 
   const addSection = () => {
     setSections(prev => [...prev, defaultSection()]);
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const removeSection = (sectionId: string) => {
     setSections(prev => prev.filter(s => s.id !== sectionId));
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const updateSectionTitle = (sectionId: string, title: string) => {
     setSections(prev => prev.map(s => s.id === sectionId ? { ...s, title } : s));
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const addItem = (sectionId: string, subsectionId: string) => {
@@ -326,7 +332,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
       ...s,
       subsections: s.subsections.map(sub => sub.id === subsectionId ? { ...sub, items: [...sub.items, defaultItem()] } : sub)
     } : s));
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const removeItem = (sectionId: string, subsectionId: string, itemId: string) => {
@@ -334,7 +340,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
       ...s,
       subsections: s.subsections.map(sub => sub.id === subsectionId ? { ...sub, items: sub.items.filter(i => i.id !== itemId) } : sub)
     } : s));
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const updateItem = (sectionId: string, subsectionId: string, itemId: string, field: keyof BOQItemRow, value: string | number) => {
@@ -358,7 +364,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
         })
       };
     }));
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const updateSubsectionLabel = (sectionId: string, subsectionId: string, label: string) => {
@@ -366,7 +372,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
       ...s,
       subsections: s.subsections.map(sub => sub.id === subsectionId ? { ...sub, label } : sub)
     } : s));
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const addSubsection = (sectionId: string) => {
@@ -378,7 +384,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
         subsections: [...s.subsections, defaultSubsection(nextLetter, `Subsection ${nextLetter}`)]
       };
     }));
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const removeSubsection = (sectionId: string, subsectionId: string) => {
@@ -389,7 +395,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
         subsections: s.subsections.filter(sub => sub.id !== subsectionId)
       };
     }));
-    setHasUnsavedChanges(true);
+    markChanged();
   };
 
   const formatCurrency = (amount: number) => {
@@ -620,17 +626,14 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
                 <Layers className="h-5 w-5 text-primary" />
                 <span>Create Bill of Quantities</span>
               </DialogTitle>
-              {lastAutosavedAt && (
-                <span className="text-xs text-gray-500">In Progress - Saved at {lastAutosavedAt}</span>
-              )}
             </div>
             <div className="flex items-center space-x-4">
-              {isSavingDraft && (
-                <div className="flex items-center space-x-2 text-green-600">
-                  <Check className="h-4 w-4" />
-                  <span className="text-sm font-medium">Autosaving...</span>
-                </div>
-              )}
+              <BOQSaveIndicator
+                isSaving={isSavingDraft}
+                lastSavedTime={lastAutosavedAt}
+                hasUnsavedChanges={hasUnsavedChanges}
+                saveError={saveError}
+              />
               {lastAutosavedAt && (
                 <Button variant="outline" size="sm" onClick={handleClearForm}>
                   Reset Draft
@@ -647,19 +650,19 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div>
               <Label>BOQ Number</Label>
-              <Input value={boqNumber} onChange={e => { setBoqNumber(e.target.value); setHasUnsavedChanges(true); }} />
+              <Input value={boqNumber} onChange={e => { setBoqNumber(e.target.value); markChanged(); }} />
             </div>
             <div>
               <Label>Date</Label>
-              <Input type="date" value={boqDate} onChange={e => { setBoqDate(e.target.value); setHasUnsavedChanges(true); }} />
+              <Input type="date" value={boqDate} onChange={e => { setBoqDate(e.target.value); markChanged(); }} />
             </div>
             <div>
               <Label>Due Date</Label>
-              <Input type="date" value={dueDate} onChange={e => { setDueDate(e.target.value); setHasUnsavedChanges(true); }} />
+              <Input type="date" value={dueDate} onChange={e => { setDueDate(e.target.value); markChanged(); }} />
             </div>
             <div>
               <Label>Currency</Label>
-              <Select value={currency} onValueChange={(val) => { setCurrency(val); setHasUnsavedChanges(true); }}>
+              <Select value={currency} onValueChange={(val) => { setCurrency(val); markChanged(); }}>
                 <SelectTrigger>
                   <SelectValue placeholder="Select currency" />
                 </SelectTrigger>
@@ -675,7 +678,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
 
           <div>
             <Label>Client</Label>
-            <Select value={clientId} onValueChange={(val) => { setClientId(val); setHasUnsavedChanges(true); }}>
+            <Select value={clientId} onValueChange={(val) => { setClientId(val); markChanged(); }}>
               <SelectTrigger>
                 <SelectValue placeholder="Select client" />
               </SelectTrigger>
@@ -690,11 +693,11 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <Label>Project Title</Label>
-              <Input value={projectTitle} onChange={e => { setProjectTitle(e.target.value); setHasUnsavedChanges(true); }} />
+              <Input value={projectTitle} onChange={e => { setProjectTitle(e.target.value); markChanged(); }} />
             </div>
             <div>
               <Label>Contractor</Label>
-              <Input value={contractor} onChange={e => { setContractor(e.target.value); setHasUnsavedChanges(true); }} />
+              <Input value={contractor} onChange={e => { setContractor(e.target.value); markChanged(); }} />
             </div>
           </div>
 
@@ -851,21 +854,21 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
 
           <div>
             <Label>Notes</Label>
-            <Textarea value={notes} onChange={e => { setNotes(e.target.value); setHasUnsavedChanges(true); }} rows={4} placeholder="Any special notes or terms" />
+            <Textarea value={notes} onChange={e => { setNotes(e.target.value); markChanged(); }} rows={4} placeholder="Any special notes or terms" />
           </div>
 
           <div>
             <Label>Terms and Conditions</Label>
             <Textarea
               value={termsAndConditions}
-              onChange={e => { setTermsAndConditions(e.target.value); setHasUnsavedChanges(true); }}
+              onChange={e => { setTermsAndConditions(e.target.value); markChanged(); }}
               rows={6}
             />
             <div className="flex items-center space-x-2 mt-3">
               <Checkbox
                 id="showCalculatedValues"
                 checked={showCalculatedValuesInTerms}
-                onCheckedChange={(checked) => { setShowCalculatedValuesInTerms(checked === true); setHasUnsavedChanges(true); }}
+                onCheckedChange={(checked) => { setShowCalculatedValuesInTerms(checked === true); markChanged(); }}
               />
               <Label htmlFor="showCalculatedValues" className="font-normal cursor-pointer">
                 Show calculated values (e.g., 50% (KES 50,000))
@@ -875,17 +878,9 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
         </div>
 
         <DialogFooter className="mt-6 flex justify-between items-center">
-          <div className="flex items-center gap-4">
-            <Button variant="destructive" onClick={handleClearForm}>
-              Clear Form
-            </Button>
-            <BOQSaveIndicator
-              isSaving={isSavingDraft}
-              lastSavedTime={lastAutosavedAt}
-              hasUnsavedChanges={hasUnsavedChanges}
-              saveError={saveError}
-            />
-          </div>
+          <Button variant="destructive" onClick={handleClearForm}>
+            Clear Form
+          </Button>
           <div className="space-x-2">
             <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
             <Button onClick={handleGenerate} disabled={submitting}>


### PR DESCRIPTION
### Summary
Improves the BOQ save indicator to clearly communicate when an autosave is pending (debouncing), so users are no longer left seeing "Unsaved changes" with no feedback during the save countdown.

### Problem
When creating a BOQ, users had no visual indication that a save was in progress during the debounce window. After making changes, the UI would show "Unsaved changes" for over a minute with no feedback, leaving users uncertain whether their work would be saved.

### Solution
Added a delayed "Autosaving in progress..." indicator with a clock icon that appears 1 second after changes are detected (while the 5-second debounce timer counts down). The save error message was also improved to communicate retry behavior, and a `markChanged` helper was introduced to clear previous save errors on new edits.

### Key Changes
- **`BOQSaveIndicator.tsx`**: Added a new pending-save state using a `Clock` icon and "Autosaving in progress..." label (shown in blue) that appears 1 second after unsaved changes are detected, bridging the gap between user edits and the actual save trigger
- **`BOQSaveIndicator.tsx`**: Updated save error message from "Save failed" to "Save failed — will retry" for clearer user feedback
- **`BOQSaveIndicator.tsx`**: Updated saving label from "Saving..." to "Saving draft..." for more descriptive feedback
- **`CreateBOQModal.tsx`**: Introduced `markChanged` helper callback that sets unsaved changes flag and clears any prior save errors, enabling auto-retry on next debounce cycle
- **`CreateBOQModal.tsx`**: Replaced all direct `setHasUnsavedChanges(true)` calls with `markChanged()` throughout the form
- **`CreateBOQModal.tsx`**: Moved `BOQSaveIndicator` from the footer to the header area for better visibility, and removed the redundant inline autosave indicator
- **`CreateBOQModal.tsx`**: Fixed autosave `useEffect` dependency array to explicitly include all form fields, ensuring the debounced save triggers correctly on every change


---

<a href="https://builder.io/app/projects/3dd56ff25feb453781ab/crimson-outpost-mfinmuxr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://3dd56ff25feb453781ab-crimson-outpost-mfinmuxr_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=3dd56ff25feb453781ab&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 235`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3dd56ff25feb453781ab</projectId>-->
<!--<branchName>crimson-outpost-mfinmuxr</branchName>-->