### PR TITLE
Fix edit BOQ modal loading without data

### DIFF
--- a/src/components/boq/EditBOQModal.tsx
+++ b/src/components/boq/EditBOQModal.tsx
@@ -277,7 +277,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
   }, []);
 
   useEffect(() => {
-    if (open && boq && boq.data && profile?.id && currentCompany?.id) {
+    if (open && boq && profile?.id && currentCompany?.id) {
       // Check if there's an edit draft for this BOQ
       const checkAndLoadDraft = async () => {
         const editDraft = await loadEditDraft(profile.id, currentCompany.id, boq.id);
@@ -287,26 +287,36 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
           ? editDraft
           : boq;
 
-        const boqData = dataToUse.data;
+        // Safely extract boq data with fallbacks
+        const boqData = dataToUse.data || {};
+
+        // Set basic fields from dataToUse (top-level fields)
         setBoqNumber(dataToUse.number || '');
         setBoqDate(dataToUse.boq_date || '');
         setDueDate(dataToUse.due_date || '');
-        setProjectTitle(boqData.project_title || '');
-        setContractor(boqData.contractor || '');
+
+        // Set fields that may be in data object or top-level
+        setProjectTitle(dataToUse.project_title || boqData.project_title || '');
+        setContractor(dataToUse.contractor || boqData.contractor || '');
         setNotes(boqData.notes || '');
 
         const termsToUse = dataToUse.terms_and_conditions || '';
         setTermsAndConditions(termsToUse);
         const showCalcValues = dataToUse.show_calculated_values_in_terms || false;
         setShowCalculatedValuesInTerms(showCalcValues);
-        setCurrency(boqData.currency || 'KES');
 
+        // Currency can be in data or top-level
+        const currencyToUse = dataToUse.currency || boqData.currency || 'KES';
+        setCurrency(currencyToUse);
+
+        // Set client ID from client_name
         const clientIdFromBoq = customers.find(c => c.name === dataToUse.client_name)?.id;
         if (clientIdFromBoq) {
           setClientId(clientIdFromBoq);
         }
 
-        if (boqData.sections && boqData.sections.length > 0) {
+        // Load sections with proper fallback
+        if (boqData.sections && Array.isArray(boqData.sections) && boqData.sections.length > 0) {
           const loadedSections: BOQSectionRow[] = boqData.sections.map((section: any) => ({
             id: `section-${generateSafeUUID()}`,
             title: section.title || 'General',
@@ -316,7 +326,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
               label: subsection.label,
               items: (subsection.items || []).map((item: any) => ({
                 id: `item-${generateSafeUUID()}`,
-                description: item.description,
+                description: item.description || '',
                 quantity: item.quantity || 1,
                 unit: item.unit_id || '',
                 rate: item.rate || 0,
@@ -325,6 +335,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
           }));
           setSections(loadedSections);
         } else {
+          // No sections found, use default
           setSections([defaultSection()]);
         }
 

--- a/src/pages/BOQs.tsx
+++ b/src/pages/BOQs.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';


### PR DESCRIPTION
### Summary
Fixes the Edit BOQ modal not populating with existing BOQ data when opened. The modal now correctly loads and displays all fields regardless of how the data is structured.

### Problem
When opening the Edit BOQ modal, fields such as project title, contractor, currency, and sections were not being populated. The modal appeared empty because the data-loading logic had overly strict conditions and assumed all fields lived inside a nested `data` object, which wasn't always the case.

### Solution
Relaxed the condition that gated data loading, added safe fallbacks for nested vs. top-level field access, and ensured all fields gracefully handle missing or undefined values.

### Key Changes
- Removed the strict `boq.data` check from the `useEffect` condition so the modal initializes even when `data` is absent or empty
- Added fallback logic to read fields from both `dataToUse` (top-level) and `boqData` (nested `data` object) for `project_title`, `contractor`, and `currency`
- Defaulted `boqData` to an empty object (`{}`) to prevent runtime errors when `data` is `null`/`undefined`
- Added `Array.isArray` guard when loading sections and defaulted `item.description` to an empty string
- Removed a duplicate `import` statement in `BOQs.tsx`

---

<a href="https://builder.io/app/projects/7a3d9a3e6a1843eda2ec/quasi-crack-uvt8en4g"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://7a3d9a3e6a1843eda2ec-quasi-crack-uvt8en4g_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=7a3d9a3e6a1843eda2ec&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 241`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7a3d9a3e6a1843eda2ec</projectId>-->
<!--<branchName>quasi-crack-uvt8en4g</branchName>-->