### PR TITLE
Fix BOQ edit modal loading without data

### DIFF
--- a/src/components/boq/CreateBOQModal.tsx
+++ b/src/components/boq/CreateBOQModal.tsx
@@ -541,7 +541,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
         attachment_url: null,
         data: doc,
         terms_and_conditions: termsAndConditions || null,
-        showCalculatedValuesInTerms: showCalculatedValuesInTerms,
+        show_calculated_values_in_terms: showCalculatedValuesInTerms,
         created_by: profile?.id || null,
       };
 

--- a/src/components/boq/EditBOQModal.tsx
+++ b/src/components/boq/EditBOQModal.tsx
@@ -280,20 +280,39 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
     if (open && boq && profile?.id && currentCompany?.id) {
       // Check if there's an edit draft for this BOQ
       const checkAndLoadDraft = async () => {
+        console.log('[EditBOQModal] Loading BOQ:', { id: boq.id, number: boq.number, hasData: !!boq.data });
+
         const editDraft = await loadEditDraft(profile.id, currentCompany.id, boq.id);
+        console.log('[EditBOQModal] Edit draft found:', !!editDraft);
 
         // Load from draft if it exists and is newer than published version
-        const dataToUse = editDraft && new Date(editDraft.updated_at) > new Date(boq.updated_at)
-          ? editDraft
-          : boq;
+        let dataToUse = boq;
+        if (editDraft) {
+          try {
+            const draftUpdated = new Date(editDraft.updated_at);
+            const boqUpdated = new Date(boq.updated_at);
+            if (draftUpdated > boqUpdated) {
+              dataToUse = editDraft;
+            }
+          } catch (err) {
+            console.error('[EditBOQModal] Error comparing dates:', err);
+            // Fall back to using boq if date comparison fails
+          }
+        }
+
+        console.log('[EditBOQModal] Using data from:', dataToUse.id === editDraft?.id ? 'draft' : 'boq');
 
         // Safely extract boq data with fallbacks
         const boqData = dataToUse.data || {};
 
         // Set basic fields from dataToUse (top-level fields)
-        setBoqNumber(dataToUse.number || '');
-        setBoqDate(dataToUse.boq_date || '');
-        setDueDate(dataToUse.due_date || '');
+        const boqNum = dataToUse.number || '';
+        const boqDateVal = dataToUse.boq_date || '';
+        const dueDateVal = dataToUse.due_date || '';
+
+        setBoqNumber(boqNum);
+        setBoqDate(boqDateVal);
+        setDueDate(dueDateVal);
 
         // Set fields that may be in data object or top-level
         setProjectTitle(dataToUse.project_title || boqData.project_title || '');
@@ -309,31 +328,48 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         const currencyToUse = dataToUse.currency || boqData.currency || 'KES';
         setCurrency(currencyToUse);
 
-        // Set client ID from client_name
-        const clientIdFromBoq = customers.find(c => c.name === dataToUse.client_name)?.id;
+        // Set client ID from client_name - with null check
+        const clientName = dataToUse.client_name || boqData.client_name;
+        const clientIdFromBoq = clientName ? customers.find(c => c.name === clientName)?.id : undefined;
         if (clientIdFromBoq) {
           setClientId(clientIdFromBoq);
         }
 
-        // Load sections with proper fallback
-        if (boqData.sections && Array.isArray(boqData.sections) && boqData.sections.length > 0) {
-          const loadedSections: BOQSectionRow[] = boqData.sections.map((section: any) => ({
-            id: `section-${generateSafeUUID()}`,
-            title: section.title || 'General',
-            subsections: (section.subsections || []).map((subsection: any) => ({
-              id: `subsection-${generateSafeUUID()}`,
-              name: subsection.name,
-              label: subsection.label,
-              items: (subsection.items || []).map((item: any) => ({
-                id: `item-${generateSafeUUID()}`,
-                description: item.description || '',
-                quantity: item.quantity || 1,
-                unit: item.unit_id || '',
-                rate: item.rate || 0,
-              })),
-            })),
-          }));
-          setSections(loadedSections);
+        // Load sections with proper fallback and validation
+        const sections = boqData.sections;
+        if (sections && Array.isArray(sections) && sections.length > 0) {
+          try {
+            const loadedSections: BOQSectionRow[] = sections.map((section: any) => {
+              // Ensure subsections is an array
+              const subsectionsArray = Array.isArray(section.subsections) ? section.subsections : [];
+
+              return {
+                id: `section-${generateSafeUUID()}`,
+                title: section.title || 'General',
+                subsections: subsectionsArray.map((subsection: any) => {
+                  // Ensure items is an array
+                  const itemsArray = Array.isArray(subsection.items) ? subsection.items : [];
+
+                  return {
+                    id: `subsection-${generateSafeUUID()}`,
+                    name: subsection.name || '',
+                    label: subsection.label || '',
+                    items: itemsArray.map((item: any) => ({
+                      id: `item-${generateSafeUUID()}`,
+                      description: item.description || '',
+                      quantity: Number(item.quantity) || 1,
+                      unit: item.unit_id || '',
+                      rate: Number(item.rate) || 0,
+                    })),
+                  };
+                }),
+              };
+            });
+            setSections(loadedSections);
+          } catch (err) {
+            console.error('Error loading sections:', err);
+            setSections([defaultSection()]);
+          }
         } else {
           // No sections found, use default
           setSections([defaultSection()]);
@@ -343,6 +379,17 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         if (editDraft) {
           setLastSavedTime(editDraft.last_autosaved_at);
         }
+
+        // Log warning if critical data is missing
+        if (!boqNum || !boqDateVal || !clientIdFromBoq) {
+          console.warn('[EditBOQModal] Missing critical BOQ data:', {
+            boqNumber: boqNum || 'MISSING',
+            boqDate: boqDateVal || 'MISSING',
+            clientId: clientIdFromBoq || 'MISSING',
+            clientName: clientName,
+          });
+        }
+
         setHasUnsavedChanges(false);
         unsavedChangesRef.current = false;
       };
@@ -564,7 +611,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         total_amount: filledSubtotal,
         data: doc,
         terms_and_conditions: termsAndConditions || null,
-        showCalculatedValuesInTerms: showCalculatedValuesInTerms,
+        show_calculated_values_in_terms: showCalculatedValuesInTerms,
       };
 
       const { error: updateError } = await supabase.from('boqs').update(payload).eq('id', boq.id);


### PR DESCRIPTION
### Summary
Fixes the BOQ edit modal opening without pre-populated data by improving data extraction, adding null safety, and correcting a field name mismatch in the save payload.

### Problem
The BOQ edit modal was opening without any data loaded — fields like BOQ number, date, client, and sections appeared empty even when a valid BOQ was selected for editing.

### Solution
Improved the data loading logic in `EditBOQModal` with safer null checks, better error handling during draft/BOQ comparison, and more robust section parsing. Also fixed a field name mismatch (`showCalculatedValuesInTerms` → `show_calculated_values_in_terms`) in both create and edit save payloads.

### Key Changes
- **Null-safe client lookup**: Added a null check on `client_name` before searching the customers list to prevent silent failures
- **Robust date comparison**: Wrapped draft vs. BOQ date comparison in a try/catch to gracefully fall back to the published BOQ on error
- **Safer section loading**: Added `Array.isArray` guards for subsections and items, with numeric coercion for `quantity` and `rate`, and a try/catch fallback to the default section
- **Field name fix**: Corrected `showCalculatedValuesInTerms` → `show_calculated_values_in_terms` in both `CreateBOQModal` and `EditBOQModal` save payloads to match the database column name
- **Diagnostic logging**: Added `console.log` and `console.warn` statements to trace data loading and flag missing critical fields during debugging


---

<a href="https://builder.io/app/projects/7d7d048a66d249cca467/cool-verse-yrqxgktw"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://7d7d048a66d249cca467-cool-verse-yrqxgktw_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=7d7d048a66d249cca467&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 242`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7d7d048a66d249cca467</projectId>-->
<!--<branchName>cool-verse-yrqxgktw</branchName>-->