### PR TITLE
Restrict dashboard and menu for sales account

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useState, useEffect, useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -103,6 +103,10 @@ export function Sidebar({ isMobile = false, isOpen = true, onClose = () => {} }:
 
   // Filter sidebar items based on user role
   const filteredSidebarItems = useMemo(() => {
+    // If profile is still loading, show all items to avoid flashing
+    if (isLoading) {
+      return sidebarItems;
+    }
     return sidebarItems.filter(item => {
       // Hide these items for sales accounts
       if (isSalesAccount && ['Payments', 'Audit Logs', 'Settings'].includes(item.title)) {
@@ -110,7 +114,7 @@ export function Sidebar({ isMobile = false, isOpen = true, onClose = () => {} }:
       }
       return true;
     });
-  }, [isSalesAccount]);
+  }, [isSalesAccount, isLoading]);
 
   useEffect(() => {
     if (!isLoading) {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lucide-react';
 import { BiolegendLogo } from '@/components/ui/biolegend-logo';
 import { useCurrentCompany } from '@/contexts/CompanyContext';
-import { useAuth } from '@/contexts/AuthContext';
+import { useIsSalesAccount } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 
 interface SidebarItem {
@@ -98,11 +98,8 @@ interface SidebarProps {
 export function Sidebar({ isMobile = false, isOpen = true, onClose = () => {} }: SidebarProps) {
   const location = useLocation();
   const { currentCompany } = useCurrentCompany();
-  const { profile } = useAuth();
+  const { isSalesAccount, isLoading } = useIsSalesAccount();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
-
-  // Check if this is the sales account by comparing email
-  const isSalesAccount = profile?.email?.toLowerCase() === 'sales@layonsconstruction.com';
 
   // Filter sidebar items based on user role
   const filteredSidebarItems = useMemo(() => {
@@ -116,11 +113,11 @@ export function Sidebar({ isMobile = false, isOpen = true, onClose = () => {} }:
   }, [isSalesAccount]);
 
   useEffect(() => {
-    if (profile?.email) {
-      console.log('🔍 Sidebar - Profile email:', profile.email, 'Normalized:', profile.email.toLowerCase(), 'isSalesAccount:', isSalesAccount);
+    if (!isLoading) {
+      console.log('🔍 Sidebar - isSalesAccount:', isSalesAccount, 'isLoading:', isLoading);
       console.log('📋 Sidebar filtered items:', filteredSidebarItems.map(item => item.title));
     }
-  }, [profile?.email, isSalesAccount, filteredSidebarItems]);
+  }, [isLoading, isSalesAccount, filteredSidebarItems]);
 
   const toggleExpanded = (title: string) => {
     setExpandedItems(prev => 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -82,7 +82,9 @@ export const useAuth = () => {
 
 export const useIsSalesAccount = () => {
   const { profile, loading } = useAuth();
-  const isSalesAccount = profile?.email?.toLowerCase().trim() === 'sales@layonsconstruction.com';
+  const isSalesAccount =
+    profile?.email?.toLowerCase().trim() === 'sales@layonsconstruction.com' &&
+    profile?.role === 'user';
   return { isSalesAccount, isLoading: loading };
 };
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -80,6 +80,12 @@ export const useAuth = () => {
   return context;
 };
 
+export const useIsSalesAccount = () => {
+  const { profile, loading } = useAuth();
+  const isSalesAccount = profile?.email?.toLowerCase().trim() === 'sales@layonsconstruction.com';
+  return { isSalesAccount, isLoading: loading };
+};
+
 interface AuthProviderProps {
   children: React.ReactNode;
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DashboardStats } from '@/components/dashboard/DashboardStats';

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { DashboardStats } from '@/components/dashboard/DashboardStats';
 import { DashboardSummaryCards } from '@/components/dashboard/DashboardSummaryCards';
 import { RecentActivity } from '@/components/dashboard/RecentActivity';

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -57,11 +57,11 @@ const Index = () => {
         </p>
       </div>
 
-      {/* Dashboard Stats */}
-      {!isSalesAccount && <DashboardStats />}
+      {/* Dashboard Stats - only show when profile is loaded and not a sales account */}
+      {!isLoading && !isSalesAccount && <DashboardStats />}
 
-      {/* Dashboard Summary Cards with Drill-down */}
-      {!isSalesAccount && <DashboardSummaryCards onDrill={handleDrillDown} />}
+      {/* Dashboard Summary Cards with Drill-down - only show when profile is loaded and not a sales account */}
+      {!isLoading && !isSalesAccount && <DashboardSummaryCards onDrill={handleDrillDown} />}
 
       {/* Main Content Grid */}
       <div className="grid gap-6 lg:grid-cols-3">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,22 +5,20 @@ import { DashboardSummaryCards } from '@/components/dashboard/DashboardSummaryCa
 import { RecentActivity } from '@/components/dashboard/RecentActivity';
 import { QuickActions } from '@/components/dashboard/QuickActions';
 import { useCompanies } from '@/hooks/useDatabase';
-import { useAuth } from '@/contexts/AuthContext';
+import { useIsSalesAccount } from '@/contexts/AuthContext';
 import SEO from '@/components/SEO';
 
 const Index = () => {
   const navigate = useNavigate();
-  const { profile } = useAuth();
+  const { isSalesAccount, isLoading } = useIsSalesAccount();
   const { data: companies } = useCompanies();
 
-  const isSalesAccount = profile?.email?.toLowerCase() === 'sales@layonsconstruction.com';
-
   useEffect(() => {
-    if (profile?.email) {
-      console.log('📊 Dashboard - Profile email:', profile.email, 'Normalized:', profile.email.toLowerCase(), 'isSalesAccount:', isSalesAccount);
+    if (!isLoading) {
+      console.log('📊 Dashboard - isSalesAccount:', isSalesAccount, 'isLoading:', isLoading);
       console.log('📊 Dashboard - DashboardStats visible:', !isSalesAccount, 'DashboardSummaryCards visible:', !isSalesAccount);
     }
-  }, [profile?.email, isSalesAccount]);
+  }, [isLoading, isSalesAccount]);
 
   const handleDrillDown = (module: string, filterType: string) => {
     // Navigate to the appropriate module with filter state


### PR DESCRIPTION
### Summary
Restricts the `sales@layonsconstruction.com` account from viewing dashboard summary cards and hides the Payments, Audit Logs, and Settings menu items from the sidebar for this user.

### Problem
The sales account user (`sales@layonsconstruction.com`) had full access to all dashboard summary cards (Total Revenue, Quotations, etc.) and all sidebar navigation items, including Payments, Audit Logs, and Settings — which should not be visible to this role.

### Solution
Introduced a dedicated `useIsSalesAccount` hook in `AuthContext` that checks both the user's email and role (`user`) to reliably identify the sales account. This hook is used in both the dashboard page and the sidebar to conditionally render components and menu items. Loading state is also respected to prevent content from flashing before the profile is resolved.

### Key Changes
- **New `useIsSalesAccount` hook** (`AuthContext.tsx`): Encapsulates the logic for identifying the sales account by checking `email === 'sales@layonsconstruction.com'` AND `role === 'user'`, and exposes an `isLoading` flag.
- **Sidebar filtering** (`Sidebar.tsx`): Uses `useIsSalesAccount` to hide `Payments`, `Audit Logs`, and `Settings` menu items for the sales account; shows all items while loading to avoid UI flicker.
- **Dashboard page** (`Index.tsx`): Uses `useIsSalesAccount` to hide `DashboardStats` and `DashboardSummaryCards` for the sales account; both components are only rendered after the profile has loaded and the user is confirmed not to be the sales account.


---

<a href="https://builder.io/app/projects/7d7d048a66d249cca467/pure-ridge-pzjnsonz"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://7d7d048a66d249cca467-pure-ridge-pzjnsonz_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=7d7d048a66d249cca467&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 243`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7d7d048a66d249cca467</projectId>-->
<!--<branchName>pure-ridge-pzjnsonz</branchName>-->