### PR TITLE
Fix Create BOQ button opening stale draft instead of new form

### DIFF
--- a/src/components/boq/CreateBOQModal.tsx
+++ b/src/components/boq/CreateBOQModal.tsx
@@ -32,7 +32,7 @@ import { downloadBOQPDF, BoqDocument } from '@/utils/boqPdfGenerator';
 import { generateNextBOQNumber } from '@/utils/boqNumberGenerator';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { saveBoqDraft, loadBoqDraft, deleteDraft } from '@/services/boqAutoSaveService';
+import { saveBoqDraft, loadBoqDraft, deleteDraft, isDraftStale } from '@/services/boqAutoSaveService';
 
 // Safe UUID generator that works in all environments
 const generateSafeUUID = (): string => {
@@ -176,18 +176,26 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
         try {
           const draft = await loadBoqDraft(profile.id, currentCompany.id);
           if (draft && draft.data) {
-            setBoqNumber(draft.number || defaultNumber);
-            setBoqDate(draft.boq_date || boqDate);
-            setDueDate(draft.due_date || dueDate);
-            setClientId(draft.customer_id || '');
-            setProjectTitle(draft.project_title || '');
-            setContractor(draft.contractor || '');
-            setNotes(draft.data?.notes || '');
-            setTermsAndConditions(draft.terms_and_conditions || termsAndConditions);
-            setShowCalculatedValuesInTerms(draft.show_calculated_values_in_terms || false);
-            setCurrency(draft.currency || currency);
-            setSections(draft.data?.sections || sections);
-            setLastAutosavedAt(draft.last_autosaved_at || null);
+            // Check if draft is stale (>30 minutes old)
+            if (isDraftStale(draft.last_autosaved_at, 30 * 60 * 1000)) {
+              console.log('[CreateBOQModal] Draft is stale, deleting and starting fresh');
+              await deleteDraft(profile.id, currentCompany.id);
+              // Start with fresh form (no restoration)
+            } else {
+              // Draft is fresh, restore it
+              setBoqNumber(draft.number || defaultNumber);
+              setBoqDate(draft.boq_date || boqDate);
+              setDueDate(draft.due_date || dueDate);
+              setClientId(draft.customer_id || '');
+              setProjectTitle(draft.project_title || '');
+              setContractor(draft.contractor || '');
+              setNotes(draft.data?.notes || '');
+              setTermsAndConditions(draft.terms_and_conditions || termsAndConditions);
+              setShowCalculatedValuesInTerms(draft.show_calculated_values_in_terms || false);
+              setCurrency(draft.currency || currency);
+              setSections(draft.data?.sections || sections);
+              setLastAutosavedAt(draft.last_autosaved_at || null);
+            }
           }
         } catch (err) {
           console.log('Failed to load draft:', err);

--- a/src/pages/BOQs.tsx
+++ b/src/pages/BOQs.tsx
@@ -23,7 +23,7 @@ import { useBOQs, useUnits } from '@/hooks/useDatabase';
 import { useAuditLog } from '@/hooks/useAuditLog';
 import { useAuditedDeleteOperations } from '@/hooks/useAuditedDeleteOperations';
 import { useConvertBoqToInvoice } from '@/hooks/useBOQ';
-import { loadBoqDraft, deleteDraft } from '@/services/boqAutoSaveService';
+import { loadBoqDraft, deleteDraft, cleanupDuplicateDrafts } from '@/services/boqAutoSaveService';
 import { generateUniqueInvoiceNumber } from '@/utils/invoiceNumberGenerator';
 import { toast } from 'sonner';
 import SEO from '@/components/SEO';
@@ -68,10 +68,13 @@ export default function BOQs() {
     }
   }, [searchParams]);
 
-  // Check for unsaved draft when company changes
+  // Check for unsaved draft when company changes and cleanup duplicates
   useEffect(() => {
     const checkForDraft = async () => {
       if (companyId && profile?.id) {
+        // Cleanup duplicate drafts silently in the background
+        await cleanupDuplicateDrafts(profile.id, companyId);
+
         const draft = await loadBoqDraft(profile.id, companyId);
         if (draft) {
           setDraftExists(true);

--- a/src/services/boqAutoSaveService.ts
+++ b/src/services/boqAutoSaveService.ts
@@ -53,7 +53,8 @@ export interface BOQDraftRecord {
 
 /**
  * Save or update a BOQ draft to the database.
- * Uses upsert logic (update if exists, insert if new).
+ * For create drafts (boq_id=null), loads existing draft first and updates by ID
+ * to avoid NULL comparison issues with the unique constraint.
  * Only one draft per user per company is allowed (for creating new BOQs).
  */
 export async function saveBoqDraft(
@@ -66,7 +67,7 @@ export async function saveBoqDraft(
       return { success: false, error: 'User ID and Company ID are required' };
     }
 
-    console.log(`[saveBoqDraft] Attempting upsert for company: ${companyId}, user: ${userId}`);
+    console.log(`[saveBoqDraft] Attempting save for company: ${companyId}, user: ${userId}`);
 
     // Prepare the payload matching the boq_drafts table schema
     const payload = {
@@ -99,22 +100,57 @@ export async function saveBoqDraft(
       last_autosaved_at: new Date().toISOString(),
     };
 
-    // Use upsert: on conflict (company_id, user_id, boq_id), update the existing draft
-    const { data, error } = await supabase
+    // Check if an existing create draft exists for this user/company
+    const { data: existingDraft, error: fetchError } = await supabase
       .from('boq_drafts')
-      .upsert([payload], {
-        onConflict: 'company_id,user_id,boq_id',
-      })
       .select('id')
+      .eq('user_id', userId)
+      .eq('company_id', companyId)
+      .is('boq_id', null)
+      .limit(1)
       .single();
 
-    if (error) {
-      console.error('[saveBoqDraft] Upsert failed:', error);
-      return { success: false, error: error.message };
+    let draftId: string | undefined;
+
+    if (fetchError && fetchError.code !== 'PGRST116') {
+      // Unexpected error (not "no rows found")
+      console.error('[saveBoqDraft] Failed to check existing draft:', fetchError);
+      return { success: false, error: fetchError.message };
     }
 
-    console.log(`[saveBoqDraft] Successfully saved/updated draft with ID: ${data?.id}`);
-    return { success: true, draftId: data?.id };
+    if (existingDraft?.id) {
+      // Update existing draft by ID
+      console.log(`[saveBoqDraft] Updating existing draft: ${existingDraft.id}`);
+      const { data, error } = await supabase
+        .from('boq_drafts')
+        .update(payload)
+        .eq('id', existingDraft.id)
+        .select('id')
+        .single();
+
+      if (error) {
+        console.error('[saveBoqDraft] Update failed:', error);
+        return { success: false, error: error.message };
+      }
+      draftId = data?.id;
+    } else {
+      // Insert new draft
+      console.log(`[saveBoqDraft] Creating new draft`);
+      const { data, error } = await supabase
+        .from('boq_drafts')
+        .insert([payload])
+        .select('id')
+        .single();
+
+      if (error) {
+        console.error('[saveBoqDraft] Insert failed:', error);
+        return { success: false, error: error.message };
+      }
+      draftId = data?.id;
+    }
+
+    console.log(`[saveBoqDraft] Successfully saved/updated draft with ID: ${draftId}`);
+    return { success: true, draftId };
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : 'Unknown error';
     console.error('[saveBoqDraft] Unexpected error:', errorMsg);
@@ -333,21 +369,53 @@ export async function saveEditingDraft(
       last_autosaved_at: new Date().toISOString(),
     };
 
-    // Use upsert: on conflict (company_id, user_id, boq_id), update the existing edit draft
-    const { data, error } = await supabase
+    // Check if an existing edit draft exists for this BOQ
+    const { data: existingDraft, error: fetchError } = await supabase
       .from('boq_drafts')
-      .upsert([payload], {
-        onConflict: 'company_id,user_id,boq_id',
-      })
       .select('id')
+      .eq('user_id', userId)
+      .eq('company_id', companyId)
+      .eq('boq_id', boqId)
       .single();
 
-    if (error) {
-      console.error('Failed to save editing draft:', error);
-      return { success: false, error: error.message };
+    let draftId: string | undefined;
+
+    if (fetchError && fetchError.code !== 'PGRST116') {
+      // Unexpected error (not "no rows found")
+      console.error('Failed to check existing edit draft:', fetchError);
+      return { success: false, error: fetchError.message };
     }
 
-    return { success: true, draftId: data?.id };
+    if (existingDraft?.id) {
+      // Update existing draft by ID
+      const { data, error } = await supabase
+        .from('boq_drafts')
+        .update(payload)
+        .eq('id', existingDraft.id)
+        .select('id')
+        .single();
+
+      if (error) {
+        console.error('Failed to update editing draft:', error);
+        return { success: false, error: error.message };
+      }
+      draftId = data?.id;
+    } else {
+      // Insert new draft
+      const { data, error } = await supabase
+        .from('boq_drafts')
+        .insert([payload])
+        .select('id')
+        .single();
+
+      if (error) {
+        console.error('Failed to insert editing draft:', error);
+        return { success: false, error: error.message };
+      }
+      draftId = data?.id;
+    }
+
+    return { success: true, draftId };
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : 'Unknown error';
     console.error('Error saving editing draft:', errorMsg);

--- a/src/services/boqAutoSaveService.ts
+++ b/src/services/boqAutoSaveService.ts
@@ -500,6 +500,33 @@ export async function deleteEditDraft(
 }
 
 /**
+ * Check if a draft is stale based on its last autosaved timestamp.
+ * A draft is considered stale if it hasn't been autosaved within the specified timeframe.
+ * @param lastAutosavedAt ISO timestamp string
+ * @param maxAgeMs Maximum age in milliseconds (default 30 minutes)
+ * @returns true if draft is stale, false if it's fresh
+ */
+export function isDraftStale(lastAutosavedAt: string | null, maxAgeMs: number = 30 * 60 * 1000): boolean {
+  if (!lastAutosavedAt) return true;
+
+  try {
+    const lastSavedTime = new Date(lastAutosavedAt).getTime();
+    const ageMs = Date.now() - lastSavedTime;
+    const isStale = ageMs > maxAgeMs;
+
+    if (isStale) {
+      const minutes = Math.floor(ageMs / 60000);
+      console.log(`[isDraftStale] Draft is stale: last saved ${minutes} minutes ago, threshold is ${maxAgeMs / 60000} minutes`);
+    }
+
+    return isStale;
+  } catch (err) {
+    console.error('[isDraftStale] Error parsing timestamp:', err);
+    return true; // Consider malformed timestamps as stale
+  }
+}
+
+/**
  * Check if a user has an unsaved draft for a company.
  * Returns true if draft exists (checks only create drafts with boq_id=NULL).
  */


### PR DESCRIPTION
### Summary
This PR fixes an issue where clicking "Create New BOQ" would restore an old draft instead of opening a fresh form. It also replaces the fragile upsert logic in the auto-save service with an explicit fetch-then-update-or-insert pattern.

### Problem
The "Create New BOQ" button was restoring the last saved draft regardless of how old it was, causing users to see a previously filled form instead of a blank new BOQ. Additionally, the upsert logic using `onConflict` with a nullable `boq_id` column was unreliable due to NULL comparison issues in the unique constraint.

### Solution
- Introduced a `isDraftStale` utility to check if a draft is older than 30 minutes; stale drafts are deleted and the form starts fresh.
- Replaced all `upsert` calls with an explicit fetch-then-update-or-insert flow to reliably handle the nullable `boq_id` constraint.
- Added a `cleanupDuplicateDrafts` call on the BOQs page to silently remove any duplicate drafts in the background.

### Key Changes
- **`boqAutoSaveService.ts`**: Added `isDraftStale(lastAutosavedAt, maxAgeMs)` function that returns `true` if a draft exceeds the age threshold (default 30 minutes). Replaced `upsert` with explicit select → update or insert logic in both `saveBoqDraft` and `saveEditingDraft`. Exported new `cleanupDuplicateDrafts` function.
- **`CreateBOQModal.tsx`**: On draft load, checks `isDraftStale`; if stale, deletes the draft and starts with a blank form instead of restoring it.
- **`BOQs.tsx`**: Calls `cleanupDuplicateDrafts` silently when the company changes, before checking for an existing draft.


---

<a href="https://builder.io/app/projects/d86c99932bdb4f89bcb9/zen-citadel-xl7xqxpl"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://d86c99932bdb4f89bcb9-zen-citadel-xl7xqxpl_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=d86c99932bdb4f89bcb9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 248`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d86c99932bdb4f89bcb9</projectId>-->
<!--<branchName>zen-citadel-xl7xqxpl</branchName>-->