### PR TITLE
Fix BOQ field key from snake_case to camelCase

### DIFF
--- a/src/components/boq/CreateBOQModal.tsx
+++ b/src/components/boq/CreateBOQModal.tsx
@@ -582,7 +582,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
         attachment_url: null,
         data: doc,
         terms_and_conditions: termsAndConditions || null,
-        show_calculated_values_in_terms: showCalculatedValuesInTerms,
+        showCalculatedValuesInTerms: showCalculatedValuesInTerms,
         created_by: profile?.id || null,
       };
 

--- a/src/components/boq/CreateBOQModal.tsx
+++ b/src/components/boq/CreateBOQModal.tsx
@@ -194,7 +194,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
               setContractor(draft.contractor || '');
               setNotes(draft.data?.notes || '');
               setTermsAndConditions(draft.terms_and_conditions || termsAndConditions);
-              setShowCalculatedValuesInTerms(draft.show_calculated_values_in_terms || false);
+              setShowCalculatedValuesInTerms(draft.showCalculatedValuesInTerms || false);
               setCurrency(draft.currency || currency);
               setSections(draft.data?.sections || sections);
               setLastAutosavedAt(draft.last_autosaved_at || null);

--- a/src/components/boq/EditBOQModal.tsx
+++ b/src/components/boq/EditBOQModal.tsx
@@ -208,7 +208,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
           notes: changes.notes,
         },
         terms_and_conditions: changes.termsAndConditions || null,
-        show_calculated_values_in_terms: changes.showCalculatedValuesInTerms,
+        showCalculatedValuesInTerms: changes.showCalculatedValuesInTerms,
       };
 
       const result = await saveEditingDraft(profile.id, currentCompany.id, boq.id, draftData);
@@ -611,7 +611,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
         total_amount: filledSubtotal,
         data: doc,
         terms_and_conditions: termsAndConditions || null,
-        show_calculated_values_in_terms: showCalculatedValuesInTerms,
+        showCalculatedValuesInTerms: showCalculatedValuesInTerms,
       };
 
       const { error: updateError } = await supabase.from('boqs').update(payload).eq('id', boq.id);

--- a/src/components/boq/EditBOQModal.tsx
+++ b/src/components/boq/EditBOQModal.tsx
@@ -322,7 +322,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess }: EditBOQModa
 
           const termsToUse = dataToUse.terms_and_conditions || '';
           setTermsAndConditions(termsToUse);
-          const showCalcValues = dataToUse.show_calculated_values_in_terms || false;
+          const showCalcValues = dataToUse.showCalculatedValuesInTerms || false;
           setShowCalculatedValuesInTerms(showCalcValues);
 
           const currencyToUse = dataToUse.currency || boqData.currency || 'KES';

--- a/src/pages/BOQs.tsx
+++ b/src/pages/BOQs.tsx
@@ -196,7 +196,7 @@ export default function BOQs() {
 
       // Use ONLY top-level columns for terms (single source of truth)
       const termsToUse = boqToUse.terms_and_conditions || '';
-      const showCalculatedValues = boqToUse.show_calculated_values_in_terms || false;
+      const showCalculatedValues = boqToUse.showCalculatedValuesInTerms || false;
 
       // Log term retrieval for diagnostics
       console.log('BOQ Terms Retrieval Diagnostic:', {
@@ -205,7 +205,7 @@ export default function BOQs() {
         hasTopLevelTerms: !!boqToUse.terms_and_conditions,
         topLevelTermsLength: boqToUse.terms_and_conditions?.length || 0,
         finalTermsLength: termsToUse.length,
-        topLevelShowCalcValues: boqToUse.show_calculated_values_in_terms,
+        topLevelShowCalcValues: boqToUse.showCalculatedValuesInTerms,
         finalShowCalcValues: showCalculatedValues,
       });
 

--- a/src/services/boqAutoSaveService.ts
+++ b/src/services/boqAutoSaveService.ts
@@ -45,7 +45,7 @@ export interface BOQDraftRecord {
   total_amount: number;
   data: any;
   terms_and_conditions: string;
-  showCalculatedValuesInTerms: boolean;
+  show_calculated_values_in_terms: boolean;
   created_at: string;
   updated_at: string;
   last_autosaved_at: string;

--- a/src/services/boqAutoSaveService.ts
+++ b/src/services/boqAutoSaveService.ts
@@ -45,7 +45,7 @@ export interface BOQDraftRecord {
   total_amount: number;
   data: any;
   terms_and_conditions: string;
-  show_calculated_values_in_terms: boolean;
+  showCalculatedValuesInTerms: boolean;
   created_at: string;
   updated_at: string;
   last_autosaved_at: string;
@@ -95,7 +95,7 @@ export async function saveBoqDraft(
         notes: formData.notes,
       },
       terms_and_conditions: formData.termsAndConditions || null,
-      show_calculated_values_in_terms: formData.showCalculatedValuesInTerms || false,
+      showCalculatedValuesInTerms: formData.showCalculatedValuesInTerms || false,
       updated_at: new Date().toISOString(),
       last_autosaved_at: new Date().toISOString(),
     };
@@ -372,7 +372,7 @@ export async function saveEditingDraft(
       total_amount: boqData.total_amount || 0,
       data: boqData.data,
       terms_and_conditions: boqData.terms_and_conditions || null,
-      show_calculated_values_in_terms: boqData.show_calculated_values_in_terms || false,
+      showCalculatedValuesInTerms: boqData.showCalculatedValuesInTerms || false,
       updated_at: new Date().toISOString(),
       last_autosaved_at: new Date().toISOString(),
     };


### PR DESCRIPTION
### Summary
This PR fixes a field key mismatch for `showCalculatedValuesInTerms` across BOQ components and services, replacing the incorrect `show_calculated_values_in_terms` snake_case key with the correct camelCase `showCalculatedValuesInTerms`.

### Problem
The `showCalculatedValuesInTerms` field was being read and written using the snake_case key `show_calculated_values_in_terms` in several places, causing the value to never be correctly retrieved or persisted — resulting in runtime errors and the setting always defaulting to `false`.

### Solution
Standardized all references to use the camelCase key `showCalculatedValuesInTerms` consistently across the codebase, aligning with the expected data shape used elsewhere.

### Key Changes
- **`CreateBOQModal.tsx`**: Updated draft read and payload write to use `showCalculatedValuesInTerms` instead of `show_calculated_values_in_terms`
- **`EditBOQModal.tsx`**: Fixed draft save payload and draft load logic to use the correct camelCase key
- **`BOQs.tsx`**: Corrected field access and diagnostic logging to use `showCalculatedValuesInTerms`
- **`boqAutoSaveService.ts`**: Updated both `saveBoqDraft` and `saveEditingDraft` to write the field under the camelCase key


---

<a href="https://builder.io/app/projects/d2df43fd6a154cd9a405/demi-wheel-xec1r87v"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://d2df43fd6a154cd9a405-demi-wheel-xec1r87v_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=d2df43fd6a154cd9a405&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 251`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d2df43fd6a154cd9a405</projectId>-->
<!--<branchName>demi-wheel-xec1r87v</branchName>-->