### PR TITLE
Fix runtime error: correct field name casing in BOQ service

### DIFF
--- a/src/services/boqAutoSaveService.ts
+++ b/src/services/boqAutoSaveService.ts
@@ -95,7 +95,7 @@ export async function saveBoqDraft(
         notes: formData.notes,
       },
       terms_and_conditions: formData.termsAndConditions || null,
-      showCalculatedValuesInTerms: formData.showCalculatedValuesInTerms || false,
+      show_calculated_values_in_terms: formData.showCalculatedValuesInTerms || false,
       updated_at: new Date().toISOString(),
       last_autosaved_at: new Date().toISOString(),
     };
@@ -299,6 +299,7 @@ export async function publishDraft(
       attachment_url: null,
       data: draft.data,
       terms_and_conditions: draft.terms_and_conditions,
+      show_calculated_values_in_terms: draft.show_calculated_values_in_terms,
       created_by: createdByUserId || null,
     };
 
@@ -372,7 +373,7 @@ export async function saveEditingDraft(
       total_amount: boqData.total_amount || 0,
       data: boqData.data,
       terms_and_conditions: boqData.terms_and_conditions || null,
-      showCalculatedValuesInTerms: boqData.showCalculatedValuesInTerms || false,
+      show_calculated_values_in_terms: boqData.show_calculated_values_in_terms || false,
       updated_at: new Date().toISOString(),
       last_autosaved_at: new Date().toISOString(),
     };


### PR DESCRIPTION
### Summary
Fixes a runtime error in the BOQ auto-save service caused by using an incorrect camelCase field name instead of the expected snake_case database column name.

### Problem
The field `showCalculatedValuesInTerms` was being used in camelCase format when interacting with the database, causing a runtime error since the actual database column is named `show_calculated_values_in_terms`.

### Solution
Renamed all occurrences of the camelCase `showCalculatedValuesInTerms` field to the correct snake_case `show_calculated_values_in_terms` to match the database schema, and ensured the field is also passed through during draft publishing.

### Key Changes
- Renamed `showCalculatedValuesInTerms` → `show_calculated_values_in_terms` in `saveBoqDraft` function
- Renamed `showCalculatedValuesInTerms` → `show_calculated_values_in_terms` in `saveEditingDraft` function
- Added the missing `show_calculated_values_in_terms` field to the `publishDraft` function payload


---

<a href="https://builder.io/app/projects/4c4cab446a1941d49a0e/snow-exit-t1cb5m2u"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://4c4cab446a1941d49a0e-snow-exit-t1cb5m2u_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=4c4cab446a1941d49a0e&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 252`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c4cab446a1941d49a0e</projectId>-->
<!--<branchName>snow-exit-t1cb5m2u</branchName>-->