### PR TITLE
Fix BOQ draft deletion after save

### DIFF
--- a/src/components/boq/CreateBOQModal.tsx
+++ b/src/components/boq/CreateBOQModal.tsx
@@ -630,7 +630,7 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
 
       toast.success(`BOQ ${boqNumber} generated and saved`);
 
-      // Clear draft from database after successful save
+      // Clear draft from database and reset form state after successful save
       if (profile?.id && currentCompany?.id) {
         const deleteResult = await deleteDraft(profile.id, currentCompany.id);
         if (!deleteResult.success) {
@@ -638,6 +638,13 @@ export function CreateBOQModal({ open, onOpenChange, onSuccess }: CreateBOQModal
           toast.warning('BOQ created but draft cleanup failed — you may see it again next time');
         }
       }
+
+      // Clear pending autosave and form state to prevent re-autosave on modal close
+      if (pendingTimeoutRef.current) {
+        clearTimeout(pendingTimeoutRef.current);
+        pendingTimeoutRef.current = null;
+      }
+      formStateRef.current = {};
 
       onSuccess?.();
       handleOpenChange(false);

--- a/src/services/boqAutoSaveService.ts
+++ b/src/services/boqAutoSaveService.ts
@@ -232,7 +232,7 @@ export async function deleteDraft(
       .delete()
       .eq('user_id', userId)
       .eq('company_id', companyId)
-      .eq('boq_id', null); // Only delete create drafts
+      .is('boq_id', null); // Only delete create drafts (use .is() for NULL comparison)
 
     if (error) {
       const errorMsg = error instanceof Error ? error.message : (error?.message || JSON.stringify(error));


### PR DESCRIPTION
### Summary
Fixes the failure to delete the associated draft after a BOQ is successfully created and saved, and prevents the form from re-autosaving on modal close.

### Problem
After saving a newly created BOQ, the deletion of the associated draft record was silently failing. This was caused by using `.eq('boq_id', null)` for a NULL comparison in the database query, which does not work correctly — SQL requires `IS NULL` semantics. Additionally, after a successful save, a pending autosave timeout could still fire and re-save the draft before the modal fully closed.

### Solution
- Fixed the NULL comparison in the draft deletion query by replacing `.eq('boq_id', null)` with `.is('boq_id', null)`.
- After a successful save, the pending autosave timeout is now cleared and the form state ref is reset to prevent any stale autosave from triggering on modal close.

### Key Changes
- **`src/services/boqAutoSaveService.ts`**: Changed `.eq('boq_id', null)` to `.is('boq_id', null)` in the `deleteDraft` function to correctly match rows where `boq_id` is NULL.
- **`src/components/boq/CreateBOQModal.tsx`**: After a successful BOQ save, clears any pending autosave timeout (`pendingTimeoutRef.current`) and resets `formStateRef.current` to an empty object before calling `onSuccess` and closing the modal.


---

<a href="https://builder.io/app/projects/4c4cab446a1941d49a0e/square-coin-netwm8ze"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://4c4cab446a1941d49a0e-square-coin-netwm8ze_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=4c4cab446a1941d49a0e&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 253`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c4cab446a1941d49a0e</projectId>-->
<!--<branchName>square-coin-netwm8ze</branchName>-->