### PR TITLE
Refactor LCL Template page to load default BOQ directly

### DIFF
--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -231,9 +231,9 @@ export function LCLTemplateEditor({
         )}
         <div className="text-right">
           <p className="text-sm font-medium">
-            Grand Total:{' '}
+            Grand Total (KES):{' '}
             <span className="text-lg font-bold">
-              {data.grand_total.toFixed(2)}
+              Ksh{data.grand_total.toFixed(2)}
             </span>
           </p>
         </div>
@@ -257,7 +257,7 @@ export function LCLTemplateEditor({
                 <h3 className="font-semibold">{section.section_name}</h3>
               </div>
               <p className="text-sm font-medium">
-                Section Total: {section.total.toFixed(2)}
+                Section Total (KES): Ksh{section.total.toFixed(2)}
               </p>
             </button>
 
@@ -284,7 +284,7 @@ export function LCLTemplateEditor({
                         </p>
                       </div>
                       <p className="text-sm">
-                        Subtotal: {subsection.subtotal.toFixed(2)}
+                        Subtotal (KES): Ksh{subsection.subtotal.toFixed(2)}
                       </p>
                     </button>
 

--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -1,185 +1,52 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 import { useToast } from '@/hooks/use-toast';
-import {
-  Download,
-  PlusCircle,
-  Trash2,
-  Edit2,
-  Eye,
-  AlertCircle,
-} from 'lucide-react';
 import { useCurrentCompany } from '@/contexts/CompanyContext';
-import { ConfirmationDialog } from '@/components/ConfirmationDialog';
-import { CreateTemplateDialog } from '@/components/lclTemplate/CreateTemplateDialog';
 import { LCLTemplateEditor } from '@/components/lclTemplate/LCLTemplateEditor';
 import { lclTemplateService } from '@/services/lclTemplateService';
-import {
-  LCLTemplateStructure,
-  LCLHierarchicalData,
-  LCLSectionDef,
-} from '@/types/lclTemplate';
-
-// Default section structure based on BOQ-085 (PROPOSED RESIDENTIAL MAISONETTE)
-const DEFAULT_SECTIONS: LCLSectionDef[] = [
-  {
-    id: 'foundation',
-    name: 'Section A: Foundation',
-    subsections: [
-      { id: 'foundation_materials', name: 'Materials' },
-      { id: 'foundation_labor', name: 'Labor' },
-    ],
-  },
-  {
-    id: 'ground_floor_walling',
-    name: 'Section B: Ground Floor Walling',
-    subsections: [
-      { id: 'gfw_materials', name: 'Materials' },
-      { id: 'gfw_labor', name: 'Labor' },
-    ],
-  },
-  {
-    id: 'ground_floor_slab',
-    name: 'Section C: Ground Floor Suspended Slab',
-    subsections: [
-      { id: 'gfs_materials', name: 'Materials' },
-      { id: 'gfs_labor', name: 'Labor' },
-    ],
-  },
-  {
-    id: 'first_floor_walling',
-    name: 'Section D: First Floor Walling & Columns',
-    subsections: [
-      { id: 'ffw_materials', name: 'Materials' },
-      { id: 'ffw_labor', name: 'Labor' },
-    ],
-  },
-  {
-    id: 'first_floor_slab',
-    name: 'Section E: First Floor Suspended Slab',
-    subsections: [
-      { id: 'ffs_materials', name: 'Materials' },
-      { id: 'ffs_labor', name: 'Labor' },
-    ],
-  },
-  {
-    id: 'second_floor_walling',
-    name: 'Section F: Second Floor Walling & Columns',
-    subsections: [
-      { id: 'sfw_materials', name: 'Materials' },
-      { id: 'sfw_labor', name: 'Labor' },
-    ],
-  },
-  {
-    id: 'second_floor_slab',
-    name: 'Section G: Second Floor Suspended Slab',
-    subsections: [
-      { id: 'sfs_materials', name: 'Materials' },
-      { id: 'sfs_labor', name: 'Labor' },
-    ],
-  },
-];
-
-type PageView = 'list' | 'editor';
+import { LCLHierarchicalData } from '@/types/lclTemplate';
 
 export default function LCLTemplate() {
   const { currentCompany } = useCurrentCompany();
   const companyId = currentCompany?.id || '';
   const { toast } = useToast();
 
-  const [pageView, setPageView] = useState<PageView>('list');
-  const [templates, setTemplates] = useState<LCLTemplateStructure[]>([]);
-  const [selectedTemplate, setSelectedTemplate] =
-    useState<LCLTemplateStructure | null>(null);
   const [hierarchicalData, setHierarchicalData] =
     useState<LCLHierarchicalData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-  const [templateToDelete, setTemplateToDelete] =
-    useState<LCLTemplateStructure | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  const loadTemplates = async () => {
+  const loadLCLBOQData = async () => {
     if (!companyId) return;
 
     setLoading(true);
     try {
-      const data = await lclTemplateService.getStructures(companyId);
-      setTemplates(data);
-    } catch (error) {
-      toast({
-        title: 'Error',
-        description:
-          error instanceof Error
-            ? error.message
-            : 'Failed to load templates',
-        variant: 'destructive',
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
+      // Load the default LCL BOQ structure for this company
+      const structures = await lclTemplateService.getStructures(companyId);
+      const lclDefaultStructure = structures.find(
+        (s) => s.name === 'LCL Default BOQ'
+      );
 
-  const loadTemplateData = async (template: LCLTemplateStructure) => {
-    setLoading(true);
-    try {
-      const data = await lclTemplateService.getHierarchicalData(template.id);
+      if (!lclDefaultStructure) {
+        toast({
+          title: 'Error',
+          description:
+            'LCL Default BOQ structure not found. Please contact support.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      // Load hierarchical data for the default structure
+      const data =
+        await lclTemplateService.getHierarchicalData(lclDefaultStructure.id);
       setHierarchicalData(data);
-      setSelectedTemplate(template);
-      setPageView('editor');
     } catch (error) {
       toast({
         title: 'Error',
         description:
           error instanceof Error
             ? error.message
-            : 'Failed to load template',
-        variant: 'destructive',
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleTemplateCreated = async (template: LCLTemplateStructure) => {
-    await loadTemplates();
-    await loadTemplateData(template);
-  };
-
-  const handleDeleteTemplate = async () => {
-    if (!templateToDelete) return;
-
-    setLoading(true);
-    try {
-      await lclTemplateService.deleteStructure(templateToDelete.id);
-      toast({
-        title: 'Success',
-        description: 'Template deleted successfully.',
-      });
-      setDeleteConfirmOpen(false);
-      setTemplateToDelete(null);
-      await loadTemplates();
-    } catch (error) {
-      toast({
-        title: 'Error',
-        description:
-          error instanceof Error
-            ? error.message
-            : 'Failed to delete template',
+            : 'Failed to load LCL BOQ',
         variant: 'destructive',
       });
     } finally {
@@ -188,40 +55,52 @@ export default function LCLTemplate() {
   };
 
   const handleDataUpdated = async () => {
-    if (!selectedTemplate) return;
-    const data = await lclTemplateService.getHierarchicalData(
-      selectedTemplate.id
-    );
-    setHierarchicalData(data);
+    // Reload the data after any updates
+    if (!companyId) return;
+
+    try {
+      const structures = await lclTemplateService.getStructures(companyId);
+      const lclDefaultStructure = structures.find(
+        (s) => s.name === 'LCL Default BOQ'
+      );
+
+      if (lclDefaultStructure) {
+        const data = await lclTemplateService.getHierarchicalData(
+          lclDefaultStructure.id
+        );
+        setHierarchicalData(data);
+      }
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Failed to refresh data',
+        variant: 'destructive',
+      });
+    }
   };
 
   useEffect(() => {
-    loadTemplates();
+    loadLCLBOQData();
   }, [companyId]);
 
-  if (pageView === 'editor' && selectedTemplate && hierarchicalData) {
+  if (loading) {
     return (
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold">LCL Template Editor</h1>
-          <Button
-            variant="outline"
-            onClick={() => {
-              setPageView('list');
-              setSelectedTemplate(null);
-              setHierarchicalData(null);
-            }}
-            disabled={loading}
-          >
-            ← Back to List
-          </Button>
-        </div>
+      <div className="flex items-center justify-center py-12">
+        <p className="text-muted-foreground">Loading LCL BOQ...</p>
+      </div>
+    );
+  }
 
-        <LCLTemplateEditor
-          data={hierarchicalData}
-          onDataUpdated={handleDataUpdated}
-          companyId={companyId}
-        />
+  if (!hierarchicalData) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <p className="text-muted-foreground mb-4">
+          Unable to load LCL BOQ structure.
+        </p>
+        <Button onClick={loadLCLBOQData}>Try Again</Button>
       </div>
     );
   }
@@ -229,100 +108,13 @@ export default function LCLTemplate() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold">LCL Templates</h1>
-        <Button onClick={() => setCreateDialogOpen(true)} disabled={loading}>
-          <PlusCircle className="h-4 w-4 mr-2" />
-          Create New Template
-        </Button>
+        <h1 className="text-3xl font-bold">LCL BOQ</h1>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Your Templates</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {templates.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center">
-              <AlertCircle className="h-12 w-12 text-muted-foreground mb-3" />
-              <p className="text-muted-foreground mb-4">
-                No templates created yet.
-              </p>
-              <Button onClick={() => setCreateDialogOpen(true)}>
-                <PlusCircle className="h-4 w-4 mr-2" />
-                Create Your First Template
-              </Button>
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Template Name</TableHead>
-                    <TableHead>Description</TableHead>
-                    <TableHead>Created</TableHead>
-                    <TableHead className="w-40">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {templates.map((template) => (
-                    <TableRow key={template.id}>
-                      <TableCell className="font-medium">
-                        {template.name}
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {template.description || '-'}
-                      </TableCell>
-                      <TableCell className="text-sm">
-                        {new Date(template.created_at).toLocaleDateString()}
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => loadTemplateData(template)}
-                            disabled={loading}
-                          >
-                            <Eye className="h-4 w-4 mr-1" />
-                            View
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() => {
-                              setTemplateToDelete(template);
-                              setDeleteConfirmOpen(true);
-                            }}
-                            disabled={loading}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <CreateTemplateDialog
-        open={createDialogOpen}
-        onOpenChange={setCreateDialogOpen}
+      <LCLTemplateEditor
+        data={hierarchicalData}
+        onDataUpdated={handleDataUpdated}
         companyId={companyId}
-        onTemplateCreated={handleTemplateCreated}
-        defaultSections={DEFAULT_SECTIONS}
-      />
-
-      <ConfirmationDialog
-        open={deleteConfirmOpen}
-        onOpenChange={setDeleteConfirmOpen}
-        title="Delete Template"
-        description={`Are you sure you want to delete "${templateToDelete?.name}"? This action cannot be undone.`}
-        onConfirm={handleDeleteTemplate}
-        isDangerous
       />
     </div>
   );

--- a/supabase/migrations/20250527_seed_lcl_default_boq.sql
+++ b/supabase/migrations/20250527_seed_lcl_default_boq.sql
@@ -1,0 +1,276 @@
+-- Seed LCL Default BOQ structure with data from BOQ-085 (PROPOSED RESIDENTIAL MAISONETTE)
+-- This migration creates a default LCL BOQ structure and populates it with all items from the PDF
+
+-- Insert a special LCL BOQ structure (per company)
+-- Note: This assumes a function or trigger will auto-create this for each company, or we seed it once globally
+-- For now, we'll create a migration-friendly approach using a placeholder company_id
+
+-- Structure definition with sections A-G
+INSERT INTO lcl_template_structures (
+  company_id,
+  name,
+  description,
+  structure_data,
+  is_active,
+  created_at,
+  updated_at
+) 
+SELECT 
+  companies.id,
+  'LCL Default BOQ',
+  'Default BOQ structure for Layons Construction projects (BOQ-085: Proposed Residential Maisonette)',
+  jsonb_build_object(
+    'sections', jsonb_build_array(
+      jsonb_build_object('id', 'section_a', 'name', 'Section A: Foundation', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_a_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_a_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_b', 'name', 'Section B: Ground Floor Walling', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_b_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_b_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_c', 'name', 'Section C: Ground Floor Suspended Slab', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_c_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_c_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_d', 'name', 'Section D: First Floor Walling and Columns', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_d_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_d_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_e', 'name', 'Section E: First Floor Suspended Slab', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_e_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_e_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_f', 'name', 'Section F: Second Floor Walling and Columns', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_f_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_f_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_g', 'name', 'Section G: Second Floor Suspended Slab', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_g_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_g_labor', 'name', 'Labor')
+      ))
+    )
+  ),
+  true,
+  NOW(),
+  NOW()
+FROM companies
+WHERE NOT EXISTS (
+  SELECT 1 FROM lcl_template_structures 
+  WHERE name = 'LCL Default BOQ' AND company_id = companies.id
+)
+ON CONFLICT DO NOTHING;
+
+-- Helper: Get the default LCL structure IDs by company
+WITH lcl_structures AS (
+  SELECT id, company_id FROM lcl_template_structures 
+  WHERE name = 'LCL Default BOQ'
+)
+INSERT INTO lcl_template_items (
+  company_id,
+  structure_id,
+  section_id,
+  subsection_id,
+  item_number,
+  description,
+  unit,
+  default_qty,
+  default_rate,
+  sort_order,
+  created_at,
+  updated_at
+)
+SELECT 
+  s.company_id,
+  s.id,
+  item.section_id,
+  item.subsection_id,
+  item.item_number,
+  item.description,
+  item.unit,
+  item.qty,
+  item.rate,
+  item.sort_order,
+  NOW(),
+  NOW()
+FROM lcl_structures s,
+LATERAL (
+  -- SECTION A: FOUNDATION - MATERIALS
+  SELECT 'section_a', 'section_a_materials', '1', 'Ballast', 'Trucks', 7, 30000, 0 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '2', 'Sand', 'Trucks', 8, 30000, 1 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '3', 'Cement', 'Bags', 230, 850, 2 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '4', 'D16', 'Pcs', 20, 2180, 3 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '5', 'D12', 'Pcs', 30, 1190, 4 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '6', 'D10', 'Pcs', 62, 825, 5 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '7', 'D8', 'Pcs', 80, 530, 6 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '8', 'Binding Wire', 'Rolls', 3, 2700, 7 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '9', 'Hacksaw Blades', 'Pcs', 10, 100, 8 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '10', 'Nails 3"', 'Kgs', 20, 180, 9 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '11', 'Nails 4"', 'Kgs', 20, 180, 10 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '12', 'Foundation Stones', 'Ft', 2800, 60, 11 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '13', 'Hoop Iron', 'Pcs', 8, 1500, 12 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '14', 'Hardcore/Murram', 'Trucks', 14, 6000, 13 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '15', 'D.p.m', 'Rolls', 8, 1500, 14 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '16', 'B.r.c A98', 'Rolls', 3, 19000, 15 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '17', 'Plumbing Items', 'Item', 1, 10000, 16 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '18', 'Termite Treatment', 'Ltrs', 2, 1200, 17 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '19', 'Timber 6 by 1', 'Ft', 800, 25, 18 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '20', 'Profiles', 'Pcs', 40, 200, 19 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '21', 'White Wash 25kg', 'Bags', 2, 250, 20 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '22', 'Setting Out Lines', 'Pcs', 10, 60, 21 UNION ALL
+  
+  -- SECTION A: FOUNDATION - LABOR
+  SELECT 'section_a', 'section_a_labor', '1', 'Setting Out', 'Item', 1, 6000, 0 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '3', 'Excavation & Levelling', 'Item', 1, 40000, 2 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '4', 'Bases & Trenches Concreting', 'Item', 1, 24000, 3 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '5', 'Masonry Works', 'Item', 1, 120000, 4 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '6', 'Formwork', 'Item', 1, 8000, 5 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '7', 'Column Concreting', 'Item', 1, 14000, 6 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '8', 'Backfilling & Compaction', 'Item', 1, 22000, 7 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '9', 'Laying Of D.p.m, Termite Treatment & Laying of B.r.c', 'Item', 1, 6000, 8 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '10', 'Plumbing Works', 'Item', 1, 8000, 9 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '11', 'Foundation Slab Concreting', 'Item', 1, 28000, 10 UNION ALL
+  
+  -- SECTION B: GROUND FLOOR WALLING - MATERIALS
+  SELECT 'section_b', 'section_b_materials', '1', 'Machine Cut Stones 9 by 9', 'Pcs', 2800, 60, 0 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '2', 'Riversand', 'Trucks', 2, 30000, 1 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '3', 'Ballast', 'Trucks', 1, 30000, 2 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '4', 'Cement', 'Bags', 90, 850, 3 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '5', 'D 16', 'Pcs', 27, 2180, 4 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '6', 'D8', 'Pcs', 20, 530, 5 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '7', 'Binding Wire', 'Rolls', 1, 2700, 6 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '8', 'Hacksaw Blades', 'Pcs', 10, 100, 7 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '9', 'Timber 6x1', 'Ft', 1000, 25, 8 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '10', 'Nails 3"', 'Kgs', 5, 180, 9 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '11', 'Nails 4"', 'Kgs', 5, 180, 10 UNION ALL
+  
+  -- SECTION B: GROUND FLOOR WALLING - LABOR
+  SELECT 'section_b', 'section_b_labor', '1', 'Setting & Levelling', 'Item', 1, 12000, 0 UNION ALL
+  SELECT 'section_b', 'section_b_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1 UNION ALL
+  SELECT 'section_b', 'section_b_labor', '3', 'Masonry works', 'Item', 1, 140000, 2 UNION ALL
+  SELECT 'section_b', 'section_b_labor', '4', 'Column Formwork', 'Item', 1, 12000, 3 UNION ALL
+  SELECT 'section_b', 'section_b_labor', '5', 'Column Concreting', 'Item', 1, 16000, 4 UNION ALL
+  
+  -- SECTION C: GROUND FLOOR SUSPENDED SLAB - MATERIALS
+  SELECT 'section_c', 'section_c_materials', '1', 'Timber 3x2', 'Ft', 2000, 25, 0 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '2', 'Timber 6x1', 'Ft', 1500, 25, 1 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '3', 'Profiles', 'Pcs', 250, 180, 2 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '4', 'Trappers', 'Pcs', 180, 120, 3 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '5', 'Nails 4"', 'Bags', 1, 8000, 4 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '6', 'Nails 3"', 'Bags', 1, 8000, 5 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '7', 'D16', 'Pcs', 12, 2180, 6 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '8', 'D12', 'Pcs', 70, 1190, 7 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '9', 'D10', 'Pcs', 320, 825, 8 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '10', 'D8', 'Pcs', 90, 530, 9 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '11', 'Binding Wire', 'Rolls', 5, 2700, 10 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '12', 'Blades', 'Pcs', 20, 100, 11 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '13', 'Ballast', 'Trucks', 6, 30000, 12 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '14', 'Riversand', 'Trucks', 4, 30000, 13 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '15', 'Cement', 'Bags', 180, 850, 14 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '16', 'Electrical Items', 'Item', 1, 15000, 15 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '17', 'Plumbing Items', 'Item', 1, 10000, 16 UNION ALL
+  
+  -- SECTION C: GROUND FLOOR SUSPENDED SLAB - LABOR
+  SELECT 'section_c', 'section_c_labor', '1', 'Formwork', 'Item', 1, 70000, 0 UNION ALL
+  SELECT 'section_c', 'section_c_labor', '2', 'Bar Bending', 'Item', 1, 60000, 1 UNION ALL
+  SELECT 'section_c', 'section_c_labor', '3', 'Electrical Works', 'Item', 1, 18000, 2 UNION ALL
+  SELECT 'section_c', 'section_c_labor', '4', 'Plumbing Works', 'Item', 1, 10000, 3 UNION ALL
+  SELECT 'section_c', 'section_c_labor', '5', 'Concreting', 'Item', 1, 40000, 4 UNION ALL
+  
+  -- SECTION D: FIRST FLOOR WALLING AND COLUMNS - MATERIALS
+  SELECT 'section_d', 'section_d_materials', '1', 'Machine Cut Stones 9 by 9', 'Pcs', 2800, 60, 0 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '2', 'Riversand', 'Trucks', 2, 30000, 1 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '3', 'Ballast', 'Trucks', 1, 30000, 2 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '4', 'Cement', 'Bags', 90, 850, 3 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '5', 'D 16', 'Pcs', 27, 2180, 4 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '6', 'D8', 'Pcs', 20, 530, 5 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '7', 'Binding wire', 'Rolls', 1, 2700, 6 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '8', 'Hacksaw Blades', 'Pcs', 10, 100, 7 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '9', 'Timber 6x1', 'Ft', 1000, 25, 8 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '10', 'Nails 3"', 'Kgs', 5, 180, 9 UNION ALL
+  SELECT 'section_d', 'section_d_materials', '11', 'Nails 4"', 'Kgs', 5, 180, 10 UNION ALL
+  
+  -- SECTION D: FIRST FLOOR WALLING AND COLUMNS - LABOR
+  SELECT 'section_d', 'section_d_labor', '1', 'Setting s Levelling', 'Item', 1, 12000, 0 UNION ALL
+  SELECT 'section_d', 'section_d_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1 UNION ALL
+  SELECT 'section_d', 'section_d_labor', '3', 'Masonry Works', 'Item', 1, 150000, 2 UNION ALL
+  SELECT 'section_d', 'section_d_labor', '4', 'Column Formwork', 'Item', 1, 12000, 3 UNION ALL
+  SELECT 'section_d', 'section_d_labor', '5', 'Column Concreting', 'Item', 1, 16000, 4 UNION ALL
+  
+  -- SECTION E: FIRST FLOOR SUSPENDED SLAB - MATERIALS
+  SELECT 'section_e', 'section_e_materials', '1', 'Timber 3x2', 'Ft', 2000, 25, 0 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '2', 'Timber 6x1', 'Ft', 1500, 25, 1 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '3', 'Profiles', 'Pcs', 250, 180, 2 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '4', 'Trappers', 'Pcs', 180, 120, 3 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '5', 'Nails 4"', 'Bags', 1, 8000, 4 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '6', 'Nails 3"', 'Bags', 1, 8000, 5 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '7', 'D16', 'Item', 12, 2180, 6 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '8', 'D12', 'Item', 70, 1190, 7 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '9', 'D10', 'Item', 320, 825, 8 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '10', 'D8', 'Item', 80, 530, 9 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '11', 'Binding Wire', 'Item', 5, 2700, 10 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '12', 'Blades', 'Item', 20, 100, 11 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '13', 'Ballast', 'Item', 6, 30000, 12 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '14', 'Riversand', 'Item', 4, 30000, 13 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '15', 'Cement', 'Bags', 180, 850, 14 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '16', 'Electrical Items', 'Item', 1, 15000, 15 UNION ALL
+  SELECT 'section_e', 'section_e_materials', '17', 'Plumbing Items', 'Item', 1, 10000, 16 UNION ALL
+  
+  -- SECTION E: FIRST FLOOR SUSPENDED SLAB - LABOR
+  SELECT 'section_e', 'section_e_labor', '1', 'Formwork', 'Item', 1, 70000, 0 UNION ALL
+  SELECT 'section_e', 'section_e_labor', '2', 'Bar Bending', 'Item', 1, 60000, 1 UNION ALL
+  SELECT 'section_e', 'section_e_labor', '3', 'Electrical Works', 'Item', 1, 18000, 2 UNION ALL
+  SELECT 'section_e', 'section_e_labor', '4', 'Plumbing Works', 'Item', 1, 10000, 3 UNION ALL
+  SELECT 'section_e', 'section_e_labor', '5', 'Concreting', 'Item', 1, 40000, 4 UNION ALL
+  
+  -- SECTION F: SECOND FLOOR WALLING AND COLUMNS - MATERIALS
+  SELECT 'section_f', 'section_f_materials', '1', 'Machine Cut Stones 9x9', 'Pcs', 1400, 60, 0 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '2', 'Riversand', 'Trucks', 1, 30000, 1 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '3', 'Ballast', 'Trucks', 1, 30000, 2 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '4', 'Cement', 'Bags', 60, 850, 3 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '5', 'D16', 'Pcs', 14, 2180, 4 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '6', 'D8', 'Pcs', 10, 530, 5 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '7', 'Binding Wire', 'Rolls', 1, 2700, 6 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '8', 'Blades', 'Pcs', 5, 100, 7 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '9', 'Timber 6X1', 'Ft', 500, 25, 8 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '10', 'Nails 3"', 'Kgs', 3, 180, 9 UNION ALL
+  SELECT 'section_f', 'section_f_materials', '11', 'Nails 4"', 'Kgs', 3, 180, 10 UNION ALL
+  
+  -- SECTION F: SECOND FLOOR WALLING AND COLUMNS - LABOR
+  SELECT 'section_f', 'section_f_labor', '1', 'Setting $ Levelling', 'Item', 6, 12000, 0 UNION ALL
+  SELECT 'section_f', 'section_f_labor', '2', 'Bar Bending', 'Item', 7, 14000, 1 UNION ALL
+  SELECT 'section_f', 'section_f_labor', '3', 'Masonry Works', 'Item', 70, 140000, 2 UNION ALL
+  SELECT 'section_f', 'section_f_labor', '4', 'Column Formwork', 'Item', 6, 12000, 3 UNION ALL
+  SELECT 'section_f', 'section_f_labor', '5', 'Column Concreting', 'Item', 8, 16000, 4 UNION ALL
+  
+  -- SECTION G: SECOND FLOOR SUSPENDED SLAB - MATERIALS
+  SELECT 'section_g', 'section_g_materials', '1', 'Timber 3x2', 'Ft', 0, 25, 0 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '2', 'Timber 6x1', 'Ft', 0, 25, 1 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '3', 'Profiles', 'Pcs', 250, 180, 2 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '4', 'Trappers', 'Pcs', 90, 180, 3 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '5', 'Nails 4"', 'Kgs', 10, 8000, 4 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '6', 'Nails 3"', 'Kgs', 10, 8000, 5 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '7', 'D16', 'Pcs', 6, 2180, 6 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '8', 'D12', 'Pcs', 35, 1180, 7 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '9', 'D10', 'Pcs', 160, 825, 8 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '10', 'D8', 'Pcs', 40, 530, 9 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '11', 'Binding Wire', 'Pcs', 2, 2700, 10 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '12', 'Blades', 'Pcs', 10, 100, 11 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '13', 'Ballast', 'Trucks', 3, 30000, 12 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '14', 'Riversand', 'Trucks', 2, 30000, 13 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '15', 'Cement', 'Bags', 90, 850, 14 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '16', 'Electrical Items', 'Item', 1, 7500, 15 UNION ALL
+  SELECT 'section_g', 'section_g_materials', '17', 'Plumbing Items', 'Item', 1, 5000, 16 UNION ALL
+  
+  -- SECTION G: SECOND FLOOR SUSPENDED SLAB - LABOR
+  SELECT 'section_g', 'section_g_labor', '1', 'Formwork', 'Item', 1, 35000, 0 UNION ALL
+  SELECT 'section_g', 'section_g_labor', '2', 'Bar Bending', 'Item', 1, 30000, 1 UNION ALL
+  SELECT 'section_g', 'section_g_labor', '3', 'Electrical Works', 'Item', 1, 90000, 2 UNION ALL
+  SELECT 'section_g', 'section_g_labor', '4', 'Plumbing Works', 'Item', 1, 5000, 3 UNION ALL
+  SELECT 'section_g', 'section_g_labor', '5', 'Concreting', 'Item', 1, 30000, 4
+) AS item(section_id, subsection_id, item_number, description, unit, qty, rate, sort_order)
+WHERE NOT EXISTS (
+  SELECT 1 FROM lcl_template_items 
+  WHERE structure_id = s.id AND section_id = item.section_id AND subsection_id = item.subsection_id AND item_number = item.item_number
+);


### PR DESCRIPTION
### Summary
Refactors the LCL Template page to behave like the Fixed BOQ page by automatically loading the "LCL Default BOQ" structure without prompting the user to create a template. Currency labels (KES/Ksh) are also added to all monetary totals in the editor.

### Problem
The LCL Templates page previously presented a list view with options to create, edit, and delete templates, prompting users to create a template before they could view or edit any BOQ data. This was inconsistent with the Fixed BOQ page experience and unnecessary for the default LCL BOQ workflow.

### Solution
The page was simplified to directly fetch and display the "LCL Default BOQ" structure on load, removing the list/editor page-view toggle, template creation dialog, and delete confirmation flow. A comprehensive seed SQL script was also added to populate the default BOQ line items across all sections.

### Key Changes
- **`LCLTemplate.tsx`**: Removed template list view, `CreateTemplateDialog`, `ConfirmationDialog`, and all related state (`templates`, `selectedTemplate`, `pageView`, `createDialogOpen`, `deleteConfirmOpen`). Page now auto-loads the `LCL Default BOQ` structure on mount and renders the editor directly.
- **`LCLTemplateEditor.tsx`**: Updated Grand Total, Section Total, and Subtotal labels to include `(KES)` and prefix values with `Ksh` for consistent currency display.
- **SQL seed script**: Added a comprehensive `INSERT` script populating default line items for Sections A–G (foundation through second floor suspended slab), covering both materials and labor subsections with quantities, rates, and sort orders.


---

<a href="https://builder.io/app/projects/7a13f4eb4bf7472c8666/sleek-door-vfzbmfur"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://7a13f4eb4bf7472c8666-sleek-door-vfzbmfur_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=7a13f4eb4bf7472c8666&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 258`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7a13f4eb4bf7472c8666</projectId>-->
<!--<branchName>sleek-door-vfzbmfur</branchName>-->