### PR TITLE
LCL BOQ: unified number generation and dual-table save

### DIFF
--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -176,7 +176,7 @@ export default function LCLTemplate() {
       const saved = await lclBoqService.saveLCLBOQ(boqData);
       setLclBoqRecord(saved);
 
-      // Create corresponding BOQ record in boqs table
+      // Create or update corresponding BOQ record in boqs table
       try {
         const customerInfo = {
           name: selectedCustomer.name,
@@ -187,7 +187,20 @@ export default function LCLTemplate() {
           country: selectedCustomer.country,
         };
 
-        await lclBoqService.createBOQFromLCLBOQ(saved, customerInfo);
+        const boqRecord = await lclBoqService.createBOQFromLCLBOQ(saved, customerInfo);
+
+        // Store the boq_id in lcl_boqs to maintain the relationship
+        if (boqRecord?.id && boqRecord.id !== saved.boq_id) {
+          await lclBoqService.saveLCLBOQ({
+            ...saved,
+            boq_id: boqRecord.id,
+          });
+          // Update local state to reflect the boq_id
+          setLclBoqRecord({
+            ...saved,
+            boq_id: boqRecord.id,
+          });
+        }
       } catch (boqCreateError) {
         console.error('Warning: Failed to create corresponding BOQ record:', boqCreateError);
         // Don't fail the save if BOQ creation fails, but warn the user

--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -9,7 +9,7 @@ import { LCLTemplateEditor } from '@/components/lclTemplate/LCLTemplateEditor';
 import { lclTemplateService } from '@/services/lclTemplateService';
 import { LCLHierarchicalData } from '@/types/lclTemplate';
 import { lclBoqService, LCLBOQRecord } from '@/services/lclBoqService';
-import { generateNextLCLBOQNumber } from '@/utils/lclBoqNumberGenerator';
+import { generateNextBOQNumber } from '@/utils/boqNumberGenerator';
 import { downloadLCLBOQPDF } from '@/utils/lclBoqPdfGenerator';
 import {
   Select,
@@ -66,15 +66,14 @@ export default function LCLTemplate() {
         await lclTemplateService.getHierarchicalData(lclDefaultStructure.id);
       setHierarchicalData(data);
 
-      // Generate next BOQ number - with error handling for table that may not exist yet
+      // Generate next BOQ number - checks both boqs and lcl_boqs tables
       try {
-        const existingBoqs = await lclBoqService.getLCLBOQs(companyId);
-        const nextNumber = generateNextLCLBOQNumber(existingBoqs);
+        const nextNumber = await generateNextBOQNumber(undefined, companyId);
         setBoqNumber(nextNumber);
       } catch (boqError) {
-        // If lcl_boqs table doesn't exist yet, just use LCL-001
-        console.log('Note: lcl_boqs table not initialized, using default number');
-        setBoqNumber('LCL-001');
+        // If error fetching from DB, use default
+        console.log('Note: Error generating BOQ number, using default');
+        setBoqNumber('BOQ-001');
       }
     } catch (error) {
       console.error('Error loading LCL BOQ:', error);
@@ -173,12 +172,36 @@ export default function LCLTemplate() {
         status: 'saved',
       };
 
+      // Save to lcl_boqs table
       const saved = await lclBoqService.saveLCLBOQ(boqData);
       setLclBoqRecord(saved);
 
+      // Create corresponding BOQ record in boqs table
+      try {
+        const customerInfo = {
+          name: selectedCustomer.name,
+          email: selectedCustomer.email,
+          phone: selectedCustomer.phone,
+          address: selectedCustomer.address,
+          city: selectedCustomer.city,
+          country: selectedCustomer.country,
+        };
+
+        await lclBoqService.createBOQFromLCLBOQ(saved, customerInfo);
+      } catch (boqCreateError) {
+        console.error('Warning: Failed to create corresponding BOQ record:', boqCreateError);
+        // Don't fail the save if BOQ creation fails, but warn the user
+        toast({
+          title: 'Partial Success',
+          description: 'LCL BOQ saved, but failed to create corresponding BOQ record. Please contact support.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
       toast({
         title: 'Success',
-        description: 'LCL BOQ saved successfully.',
+        description: 'LCL BOQ and corresponding BOQ record saved successfully.',
       });
     } catch (error) {
       console.error('Error saving LCL BOQ:', error);

--- a/src/services/lclBoqService.ts
+++ b/src/services/lclBoqService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/integrations/supabase/client';
+import { BOQData } from '@/utils/boqHelper';
 
 export interface LCLBOQRecord {
   id?: string;
@@ -111,6 +112,98 @@ class LCLBOQService {
       ...boq,
       status: 'saved',
     });
+  }
+
+  /**
+   * Create a corresponding BOQ record from an LCL BOQ
+   * Uses upsert logic to handle re-saves (if same number exists, update it)
+   */
+  async createBOQFromLCLBOQ(
+    lclBoq: LCLBOQRecord,
+    customerData: { name?: string; email?: string; phone?: string; address?: string; city?: string; country?: string } | null,
+    createdBy?: string
+  ): Promise<BOQData> {
+    // Calculate totals from items_snapshot
+    const items = lclBoq.items_snapshot || [];
+    let subtotal = 0;
+    items.forEach((item: any) => {
+      const itemTotal = (item.qty || 0) * (item.rate || 0);
+      subtotal += itemTotal;
+    });
+
+    // Create hierarchical data structure for BOQ
+    const boqData = {
+      sections: [
+        {
+          title: 'Items',
+          subsections: [
+            {
+              name: 'A',
+              label: 'Items',
+              items: items.map((item: any) => ({
+                description: item.description,
+                quantity: item.qty || 0,
+                unit: item.unit || '',
+                rate: item.rate || 0,
+              })),
+            },
+          ],
+        },
+      ],
+    };
+
+    const boqRecord: Omit<BOQData, 'id'> = {
+      number: lclBoq.number,
+      company_id: lclBoq.company_id,
+      boq_date: lclBoq.boq_date || new Date().toISOString().split('T')[0],
+      project_title: lclBoq.project_title || '',
+      client_name: customerData?.name || '',
+      client_email: customerData?.email,
+      client_phone: customerData?.phone,
+      client_address: customerData?.address,
+      client_city: customerData?.city,
+      client_country: customerData?.country,
+      currency: 'KES',
+      subtotal,
+      tax_amount: 0,
+      total_amount: subtotal,
+      data: boqData,
+      created_by: createdBy,
+    };
+
+    // Check if BOQ with this number already exists for this company
+    const { data: existingBoq } = await supabase
+      .from('boqs')
+      .select('id')
+      .eq('company_id', lclBoq.company_id)
+      .eq('number', lclBoq.number)
+      .single();
+
+    if (existingBoq) {
+      // Update existing BOQ
+      const { data, error } = await supabase
+        .from('boqs')
+        .update({
+          ...boqRecord,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', existingBoq.id)
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as BOQData;
+    } else {
+      // Insert new BOQ
+      const { data, error } = await supabase
+        .from('boqs')
+        .insert([boqRecord])
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as BOQData;
+    }
   }
 }
 

--- a/src/services/lclBoqService.ts
+++ b/src/services/lclBoqService.ts
@@ -14,6 +14,7 @@ export interface LCLBOQRecord {
   created_at?: string;
   updated_at?: string;
   created_by?: string;
+  boq_id?: string | null;
 }
 
 class LCLBOQService {
@@ -117,6 +118,7 @@ class LCLBOQService {
   /**
    * Create a corresponding BOQ record from an LCL BOQ
    * Uses upsert logic to handle re-saves (if same number exists, update it)
+   * Returns the created/updated BOQ with its ID so the relationship can be tracked
    */
   async createBOQFromLCLBOQ(
     lclBoq: LCLBOQRecord,
@@ -171,6 +173,22 @@ class LCLBOQService {
       created_by: createdBy,
     };
 
+    // Check if BOQ already exists by boq_id (for updates)
+    if (lclBoq.boq_id) {
+      const { data, error } = await supabase
+        .from('boqs')
+        .update({
+          ...boqRecord,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', lclBoq.boq_id)
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as BOQData;
+    }
+
     // Check if BOQ with this number already exists for this company
     const { data: existingBoq } = await supabase
       .from('boqs')
@@ -180,7 +198,7 @@ class LCLBOQService {
       .single();
 
     if (existingBoq) {
-      // Update existing BOQ
+      // Update existing BOQ (shouldn't happen if boq_id is set, but fallback)
       const { data, error } = await supabase
         .from('boqs')
         .update({

--- a/src/utils/boqNumberGenerator.ts
+++ b/src/utils/boqNumberGenerator.ts
@@ -1,19 +1,46 @@
+import { supabase } from '@/integrations/supabase/client';
+
 /**
  * Generates the next sequential BOQ number in format BOQ-NNN (e.g., BOQ-001, BOQ-002)
+ * Can be used synchronously with existingBOQs array, or asynchronously with companyId
  * @param existingBOQs - Array of BOQ objects with a 'number' property
- * @returns Next BOQ number formatted as BOQ-NNN
+ * @param companyId - Optional: Company ID to fetch existing BOQs from database (async mode)
+ * @returns Next BOQ number formatted as BOQ-NNN (or Promise<string> if using companyId)
  */
-export function generateNextBOQNumber(existingBOQs: Array<{ number: string }>): string {
+export function generateNextBOQNumber(existingBOQs: Array<{ number: string }>): string;
+export function generateNextBOQNumber(
+  existingBOQs: Array<{ number: string }> | undefined,
+  companyId: string
+): Promise<string>;
+export function generateNextBOQNumber(
+  existingBOQs?: Array<{ number: string }>,
+  companyId?: string
+): string | Promise<string> {
+  // Synchronous mode: if existingBOQs provided and no companyId
+  if (existingBOQs && !companyId) {
+    return generateNextBOQNumberSync(existingBOQs);
+  }
+
+  // Async mode: if companyId provided
+  if (companyId) {
+    return generateNextBOQNumberAsync(existingBOQs, companyId);
+  }
+
+  // Default: empty array
+  return generateNextBOQNumberSync([]);
+}
+
+/**
+ * Synchronous version - uses provided array only
+ */
+function generateNextBOQNumberSync(existingBOQs: Array<{ number: string }>): string {
   if (!existingBOQs || existingBOQs.length === 0) {
     return 'BOQ-001';
   }
 
-  // Extract numeric part only from sequential BOQ numbers (BOQ-NNN format)
-  // Ignore date-based BOQ numbers (BOQ-YYYYMMDD-XXXX format)
   let maxNumber = 0;
 
   existingBOQs.forEach((boq) => {
-    // Match only BOQ-NNN format where NNN is 1-3 digits and not followed by a dash
     const match = boq.number.match(/^BOQ-(\d{1,3})$/);
     if (match && match[1]) {
       const numericPart = parseInt(match[1], 10);
@@ -23,9 +50,40 @@ export function generateNextBOQNumber(existingBOQs: Array<{ number: string }>): 
     }
   });
 
-  // Generate next number with leading zeros
   const nextNumber = maxNumber + 1;
   const formattedNumber = String(nextNumber).padStart(3, '0');
-
   return `BOQ-${formattedNumber}`;
+}
+
+/**
+ * Asynchronous version - fetches from both boqs and lcl_boqs tables
+ */
+async function generateNextBOQNumberAsync(
+  existingBOQs: Array<{ number: string }> | undefined,
+  companyId: string
+): Promise<string> {
+  let allBOQs: Array<{ number: string }> = existingBOQs || [];
+
+  try {
+    const [boqsResult, lclBoqsResult] = await Promise.all([
+      supabase
+        .from('boqs')
+        .select('number')
+        .eq('company_id', companyId),
+      supabase
+        .from('lcl_boqs')
+        .select('number')
+        .eq('company_id', companyId),
+    ]);
+
+    allBOQs = [
+      ...(boqsResult.data || []),
+      ...(lclBoqsResult.data || []),
+    ];
+  } catch (error) {
+    console.error('Error fetching BOQ numbers:', error);
+    allBOQs = existingBOQs || [];
+  }
+
+  return generateNextBOQNumberSync(allBOQs);
 }

--- a/supabase/migrations/20250527_add_boq_id_to_lcl_boqs.sql
+++ b/supabase/migrations/20250527_add_boq_id_to_lcl_boqs.sql
@@ -1,0 +1,7 @@
+-- Add boq_id column to lcl_boqs to track the relationship with boqs records
+-- This enables syncing LCL changes to the corresponding BOQ record
+ALTER TABLE lcl_boqs
+ADD COLUMN boq_id UUID REFERENCES boqs(id) ON DELETE SET NULL;
+
+-- Create index for efficient lookups
+CREATE INDEX IF NOT EXISTS idx_lcl_boqs_boq_id ON lcl_boqs(boq_id);


### PR DESCRIPTION
### Summary
LCL BOQs now use the same `BOQ-NNN` number format as regular BOQs, and saving an LCL BOQ automatically creates or updates a corresponding record in the `boqs` table so it appears in the main BOQ list.

### Problem
LCL BOQs used a separate `LCL-NNN` numbering sequence and were only stored in the `lcl_boqs` table, making them invisible in the main BOQ list. There was also no cross-table uniqueness check, meaning LCL and regular BOQ numbers could conflict.

### Solution
- Replaced the LCL-specific number generator with an enhanced `generateNextBOQNumber` that queries both `boqs` and `lcl_boqs` tables to produce a globally unique `BOQ-NNN` number.
- After saving to `lcl_boqs`, the save handler now calls a new `createBOQFromLCLBOQ` service method that inserts (or updates) a matching record in the `boqs` table.
- A new `boq_id` foreign key column on `lcl_boqs` tracks the relationship between the two records and enables upsert logic on re-saves.

### Key Changes
- **`src/utils/boqNumberGenerator.ts`** — Added overloaded async mode: when a `companyId` is supplied, the generator fetches numbers from both `boqs` and `lcl_boqs` in parallel before computing the next sequence value. Synchronous behaviour is preserved for existing callers.
- **`src/services/lclBoqService.ts`** — Added `createBOQFromLCLBOQ()` method that maps LCL BOQ fields (including flattened `items_snapshot`) to the `boqs` schema, populates denormalized client fields from customer data, and uses upsert logic (by `boq_id` or `company_id + number`) to avoid duplicate records.
- **`src/pages/LCLTemplate.tsx`** — Switched number generation to `generateNextBOQNumber(undefined, companyId)` and extended the save handler to call `createBOQFromLCLBOQ`, store the returned `boq_id` back on the LCL record, and surface a partial-success toast if the secondary save fails without blocking the primary save.
- **`supabase/migrations/20250527_add_boq_id_to_lcl_boqs.sql`** — Adds a nullable `boq_id UUID` foreign key (with `ON DELETE SET NULL`) and an index to `lcl_boqs` for efficient relationship lookups.


---

<a href="https://builder.io/app/projects/c77bdc5f8d424ce4891b/macro-queue-x8rtwrnx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://c77bdc5f8d424ce4891b-macro-queue-x8rtwrnx_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=c77bdc5f8d424ce4891b&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 262`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c77bdc5f8d424ce4891b</projectId>-->
<!--<branchName>macro-queue-x8rtwrnx</branchName>-->