### PR TITLE
Mark LCL-linked BOQs as read-only in BOQ list

### DIFF
--- a/src/pages/BOQs.tsx
+++ b/src/pages/BOQs.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginationControls } from '@/components/pagination/PaginationControls';
 import { usePagination } from '@/hooks/usePagination';
-import { Layers, Plus, Eye, Download, Trash2, Copy, Pencil, FileText, Filter, Search, AlertCircle, Clock, CheckCircle, X } from 'lucide-react';
+import { Layers, Plus, Eye, Download, Trash2, Copy, Pencil, FileText, Filter, Search, AlertCircle, Clock, CheckCircle, X, Lock } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { CreateBOQModal } from '@/components/boq/CreateBOQModal';
 import { CreatePercentageCopyModal } from '@/components/boq/CreatePercentageCopyModal';
@@ -39,6 +39,7 @@ export default function BOQs() {
   const [dueDateFromFilter, setDueDateFromFilter] = useState('');
   const [dueDateToFilter, setDueDateToFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState<'all' | 'overdue' | 'aging' | 'current'>('all');
+  const [linkedBOQIds, setLinkedBOQIds] = useState<Set<string>>(new Set());
 
   // Hooks and context calls first
   const { currentCompany } = useCurrentCompany();
@@ -59,6 +60,33 @@ export default function BOQs() {
   const [draftExists, setDraftExists] = useState(false);
   const [draftLastSaved, setDraftLastSaved] = useState<string | null>(null);
   const [showDraftBanner, setShowDraftBanner] = useState(false);
+
+  // Helper function to refresh linked BOQ IDs
+  const refreshLinkedBOQIds = async () => {
+    if (!companyId) return;
+    try {
+      const { data, error } = await supabase
+        .from('lcl_boqs')
+        .select('boq_id')
+        .eq('company_id', companyId)
+        .not('boq_id', 'is', null);
+
+      if (error) {
+        console.error('Failed to fetch linked BOQ IDs:', error);
+        return;
+      }
+
+      const ids = new Set(data?.map((record: any) => record.boq_id).filter(Boolean) || []);
+      setLinkedBOQIds(ids);
+    } catch (err) {
+      console.error('Error fetching linked BOQ IDs:', err);
+    }
+  };
+
+  // Fetch linked BOQ IDs from lcl_boqs table
+  useEffect(() => {
+    refreshLinkedBOQIds();
+  }, [companyId]);
 
   // Set status filter from URL params
   useEffect(() => {
@@ -262,6 +290,13 @@ export default function BOQs() {
   };
 
   const handleDeleteClick = (id: string, number: string) => {
+    if (linkedBOQIds.has(id)) {
+      toast.error('Cannot delete BOQ', {
+        description: `This BOQ is linked to an LCL template. Edit it in the LCL Template instead.`,
+        duration: 5000
+      });
+      return;
+    }
     setDeleteDialog({ open: true, boqId: id, boqNumber: number });
   };
 
@@ -282,6 +317,13 @@ export default function BOQs() {
       toast.success('BOQ deleted');
       setDeleteDialog({ open: false });
       refetchBOQs();
+
+      // Also refresh linked BOQ IDs in case any lcl_boqs records were affected
+      setLinkedBOQIds(prev => {
+        const updated = new Set(prev);
+        updated.delete(deleteDialog.boqId || '');
+        return updated;
+      });
     } catch (err) {
       let errorMessage = 'Failed to delete BOQ';
 
@@ -675,9 +717,17 @@ export default function BOQs() {
                         <TableCell className="hidden lg:table-cell text-xs md:text-sm">{b.project_title || '-'}</TableCell>
                         <TableCell className="text-xs md:text-sm"><Badge variant="outline" className="text-xs">{b.currency || 'KES'}</Badge></TableCell>
                         <TableCell className="text-xs md:text-sm">
-                          <Badge variant={b.status === 'converted' ? 'default' : b.status === 'cancelled' ? 'destructive' : 'secondary'} className="text-xs">
-                            {b.status === 'draft' ? 'Draft' : b.status === 'converted' ? 'Converted' : 'Cancelled'}
-                          </Badge>
+                          <div className="flex flex-col gap-1">
+                            <Badge variant={b.status === 'converted' ? 'default' : b.status === 'cancelled' ? 'destructive' : 'secondary'} className="text-xs w-fit">
+                              {b.status === 'draft' ? 'Draft' : b.status === 'converted' ? 'Converted' : 'Cancelled'}
+                            </Badge>
+                            {linkedBOQIds.has(b.id) && (
+                              <Badge variant="outline" className="text-xs w-fit flex items-center gap-1">
+                                <Lock className="h-3 w-3" />
+                                Linked to LCL
+                              </Badge>
+                            )}
+                          </div>
                         </TableCell>
                         <TableCell className="text-right text-xs md:text-sm">{new Intl.NumberFormat('en-KE', { style: 'currency', currency: b.currency || 'KES' }).format(Number(b.total_amount || b.subtotal || 0))}</TableCell>
                         <TableCell>
@@ -685,7 +735,14 @@ export default function BOQs() {
                             <Button size="icon" variant="ghost" onClick={() => setViewing(b)} title="View" className="h-8 w-8 md:h-9 md:w-9">
                               <Eye className="h-3 w-3 md:h-4 md:w-4" />
                             </Button>
-                            <Button size="icon" variant="ghost" onClick={() => setEditing(b)} title="Edit" className="h-8 w-8 md:h-9 md:w-9">
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => !linkedBOQIds.has(b.id) && setEditing(b)}
+                              title={linkedBOQIds.has(b.id) ? "Read-only: Linked to LCL template" : "Edit"}
+                              disabled={linkedBOQIds.has(b.id)}
+                              className="h-8 w-8 md:h-9 md:w-9"
+                            >
                               <Pencil className="h-3 w-3 md:h-4 md:w-4" />
                             </Button>
                             <Button size="icon" variant="ghost" onClick={() => handleDownloadPDF(b)} title="Download PDF" className="h-8 w-8 md:h-9 md:w-9">
@@ -710,7 +767,7 @@ export default function BOQs() {
                               variant="outline"
                               onClick={() => handleConvertClick(b.id, b.number)}
                               title="Convert to Invoice"
-                              disabled={b.converted_to_invoice_id !== null && b.converted_to_invoice_id !== undefined}
+                              disabled={b.converted_to_invoice_id !== null && b.converted_to_invoice_id !== undefined || linkedBOQIds.has(b.id)}
                               className="h-8 w-8 md:h-9 md:w-9"
                             >
                               <FileText className="h-3 w-3 md:h-4 md:w-4" />
@@ -719,8 +776,8 @@ export default function BOQs() {
                               size="icon"
                               variant="destructive"
                               onClick={() => handleDeleteClick(b.id, b.number)}
-                              title={b.converted_to_invoice_id ? "Cannot delete converted BOQ" : "Delete"}
-                              disabled={!!b.converted_to_invoice_id}
+                              title={linkedBOQIds.has(b.id) ? "Cannot delete: Linked to LCL template" : b.converted_to_invoice_id ? "Cannot delete converted BOQ" : "Delete"}
+                              disabled={!!b.converted_to_invoice_id || linkedBOQIds.has(b.id)}
                               className="h-8 w-8 md:h-9 md:w-9"
                             >
                               <Trash2 className="h-3 w-3 md:h-4 md:w-4" />
@@ -746,13 +803,19 @@ export default function BOQs() {
         </CardContent>
       </Card>
 
-      <CreateBOQModal open={open} onOpenChange={setOpen} onSuccess={() => refetchBOQs()} />
+      <CreateBOQModal open={open} onOpenChange={setOpen} onSuccess={() => {
+        refetchBOQs();
+        refreshLinkedBOQIds();
+      }} />
 
       <CreatePercentageCopyModal
         open={percentageCopyOpen}
         onOpenChange={setPercentageCopyOpen}
         companyId={companyId || ''}
-        onSuccess={() => refetchBOQs()}
+        onSuccess={() => {
+          refetchBOQs();
+          refreshLinkedBOQIds();
+        }}
       />
 
       {viewing && (() => {
@@ -918,7 +981,10 @@ export default function BOQs() {
           open={!!editing}
           onOpenChange={(isOpen) => setEditing(isOpen ? editing : null)}
           boq={editing}
-          onSuccess={() => refetchBOQs()}
+          onSuccess={() => {
+            refetchBOQs();
+            refreshLinkedBOQIds();
+          }}
         />
       )}
 


### PR DESCRIPTION
### Summary
This PR adds read-only enforcement for BOQs that are linked to LCL templates, preventing users from accidentally editing or deleting them directly from the BOQ list.

### Problem
When an LCL BOQ is saved, it creates a corresponding entry in the `boqs` table. However, users could still edit or delete these linked BOQs directly from the BOQ list, which would desync the data from the LCL template that is the source of truth.

### Solution
The BOQ list now fetches all `boq_id` values from the `lcl_boqs` table and tracks them in a local `Set`. Any BOQ whose ID appears in that set is treated as read-only — its edit, delete, and convert-to-invoice actions are disabled, and a "Linked to LCL" badge is displayed.

### Key Changes
- **`linkedBOQIds` state** — a `Set<string>` populated by querying `lcl_boqs.boq_id` for the current company, refreshed on mount and after any BOQ create/edit/copy operation.
- **`refreshLinkedBOQIds()`** — helper function that fetches linked BOQ IDs from Supabase and updates state.
- **Edit button** — disabled with tooltip `"Read-only: Linked to LCL template"` for linked BOQs.
- **Delete button** — disabled and shows a toast error explaining the BOQ must be edited via the LCL Template.
- **Convert-to-invoice button** — disabled for linked BOQs.
- **"Linked to LCL" badge** — displayed alongside the status badge in the BOQ list row, with a `Lock` icon, for clear visual indication.
- **Local state cleanup** — after a successful delete, the deleted ID is removed from `linkedBOQIds` to keep state consistent.


---

<a href="https://builder.io/app/projects/02aab490538548f1929e/dense-dial-31tgv8rb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://02aab490538548f1929e-dense-dial-31tgv8rb_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=02aab490538548f1929e&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 263`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>02aab490538548f1929e</projectId>-->
<!--<branchName>dense-dial-31tgv8rb</branchName>-->