### PR TITLE
Fix LCL BOQ runtime error and add missing items

### DIFF
--- a/db-scripts/add-lcl-boq-items.sql
+++ b/db-scripts/add-lcl-boq-items.sql
@@ -1,0 +1,264 @@
+-- =========================================================
+-- UPDATE AND INSERT: LCL BOQ ADDITIONAL ITEMS
+-- =========================================================
+-- This script adds the missing items to the LCL Default BOQ template
+-- based on the BOQ-086 specification from Layons Construction Limited
+
+-- =========================================================
+-- SECTION A: FOUNDATION - MATERIALS
+-- =========================================================
+-- Add items before D16 (need to renumber existing D16, D12, D10, D8 items)
+
+-- First, update existing items in Section A to make room for new items
+UPDATE lcl_template_items
+SET item_number = '6'
+WHERE section_id = 'section_a' 
+  AND subsection_id = 'section_a_materials'
+  AND description = 'D16'
+  AND sort_order = 3;
+
+UPDATE lcl_template_items
+SET item_number = '7'
+WHERE section_id = 'section_a' 
+  AND subsection_id = 'section_a_materials'
+  AND description = 'D12'
+  AND sort_order = 4;
+
+UPDATE lcl_template_items
+SET item_number = '8'
+WHERE section_id = 'section_a' 
+  AND subsection_id = 'section_a_materials'
+  AND description = 'D10'
+  AND sort_order = 5;
+
+UPDATE lcl_template_items
+SET item_number = '9'
+WHERE section_id = 'section_a' 
+  AND subsection_id = 'section_a_materials'
+  AND description = 'D8'
+  AND sort_order = 6;
+
+-- Now insert the new items for Section A Materials (before D16)
+WITH section_a_struct AS (
+  SELECT id, company_id FROM lcl_template_structures
+  WHERE name = 'LCL Default BOQ'
+)
+INSERT INTO lcl_template_items (
+  company_id,
+  structure_id,
+  section_id,
+  subsection_id,
+  item_number,
+  description,
+  unit,
+  default_qty,
+  default_rate,
+  sort_order,
+  created_at,
+  updated_at
+)
+SELECT
+  s.company_id,
+  s.id,
+  'section_a',
+  'section_a_materials',
+  item.item_number,
+  item.description,
+  item.unit,
+  item.qty,
+  item.rate,
+  item.sort_order,
+  NOW(),
+  NOW()
+FROM section_a_struct s
+CROSS JOIN LATERAL (
+  VALUES
+  ('4', 'Quarry Dust', 'Trucks', 1, 30000, 3),
+  ('5', 'Rock Sand', 'Trucks', 2, 30000, 4),
+  ('6', 'D20', 'Pcs', 10, 1000, 5)
+) AS item(item_number, description, unit, qty, rate, sort_order)
+WHERE NOT EXISTS (
+  SELECT 1 FROM lcl_template_items li
+  WHERE li.structure_id = s.id
+  AND li.section_id = 'section_a'
+  AND li.subsection_id = 'section_a_materials'
+  AND li.description = item.description
+);
+
+-- =========================================================
+-- SECTION B: GROUND FLOOR WALLING - MATERIALS
+-- =========================================================
+
+-- Update existing items in Section B Materials to make room
+UPDATE lcl_template_items
+SET item_number = '4'
+WHERE section_id = 'section_b' 
+  AND subsection_id = 'section_b_materials'
+  AND description = 'Machine Cut Stones 9 by 9'
+  AND sort_order = 0;
+
+UPDATE lcl_template_items
+SET item_number = '5'
+WHERE section_id = 'section_b' 
+  AND subsection_id = 'section_b_materials'
+  AND description = 'Machine-cut 6x9'
+  AND sort_order = 1;
+
+-- Insert new items for Section B Materials (after item 1, before the existing 2)
+WITH section_b_struct AS (
+  SELECT id, company_id FROM lcl_template_structures
+  WHERE name = 'LCL Default BOQ'
+)
+INSERT INTO lcl_template_items (
+  company_id,
+  structure_id,
+  section_id,
+  subsection_id,
+  item_number,
+  description,
+  unit,
+  default_qty,
+  default_rate,
+  sort_order,
+  created_at,
+  updated_at
+)
+SELECT
+  s.company_id,
+  s.id,
+  'section_b',
+  'section_b_materials',
+  item.item_number,
+  item.description,
+  item.unit,
+  item.qty,
+  item.rate,
+  item.sort_order,
+  NOW(),
+  NOW()
+FROM section_b_struct s
+CROSS JOIN LATERAL (
+  VALUES
+  ('2', 'Machine-cut 6x9', 'Pcs', 100, 60, 1),
+  ('3', 'Quarry dust', 'Trucks', 1, 30000, 2),
+  ('3', 'Rock sand', 'Trucks', 2, 30000, 3)
+) AS item(item_number, description, unit, qty, rate, sort_order)
+WHERE NOT EXISTS (
+  SELECT 1 FROM lcl_template_items li
+  WHERE li.structure_id = s.id
+  AND li.section_id = 'section_b'
+  AND li.subsection_id = 'section_b_materials'
+  AND li.description = item.description
+);
+
+-- Insert D20, D12, D10, D8 for Section B Materials
+WITH section_b_struct AS (
+  SELECT id, company_id FROM lcl_template_structures
+  WHERE name = 'LCL Default BOQ'
+)
+INSERT INTO lcl_template_items (
+  company_id,
+  structure_id,
+  section_id,
+  subsection_id,
+  item_number,
+  description,
+  unit,
+  default_qty,
+  default_rate,
+  sort_order,
+  created_at,
+  updated_at
+)
+SELECT
+  s.company_id,
+  s.id,
+  'section_b',
+  'section_b_materials',
+  item.item_number,
+  item.description,
+  item.unit,
+  item.qty,
+  item.rate,
+  item.sort_order,
+  NOW(),
+  NOW()
+FROM section_b_struct s
+CROSS JOIN LATERAL (
+  VALUES
+  ('6', 'D20', 'Pcs', 10, 1000, 5),
+  ('7', 'D16', 'Pcs', 20, 2180, 6),
+  ('8', 'D12', 'Pcs', 30, 1190, 7),
+  ('9', 'D10', 'Pcs', 62, 825, 8),
+  ('10', 'D8', 'Pcs', 80, 530, 9)
+) AS item(item_number, description, unit, qty, rate, sort_order)
+WHERE NOT EXISTS (
+  SELECT 1 FROM lcl_template_items li
+  WHERE li.structure_id = s.id
+  AND li.section_id = 'section_b'
+  AND li.subsection_id = 'section_b_materials'
+  AND li.description = item.description
+);
+
+-- =========================================================
+-- SECTION C: GROUND FLOOR SUSPENDED SLAB - MATERIALS
+-- =========================================================
+
+-- Update Sand to change from Riversand (if needed)
+UPDATE lcl_template_items
+SET description = 'Sand'
+WHERE section_id = 'section_c' 
+  AND subsection_id = 'section_c_materials'
+  AND (description = 'Riversand' OR description = 'riversand');
+
+-- Insert new items for Section C Materials (after Sand)
+WITH section_c_struct AS (
+  SELECT id, company_id FROM lcl_template_structures
+  WHERE name = 'LCL Default BOQ'
+)
+INSERT INTO lcl_template_items (
+  company_id,
+  structure_id,
+  section_id,
+  subsection_id,
+  item_number,
+  description,
+  unit,
+  default_qty,
+  default_rate,
+  sort_order,
+  created_at,
+  updated_at
+)
+SELECT
+  s.company_id,
+  s.id,
+  'section_c',
+  'section_c_materials',
+  item.item_number,
+  item.description,
+  item.unit,
+  item.qty,
+  item.rate,
+  item.sort_order,
+  NOW(),
+  NOW()
+FROM section_c_struct s
+CROSS JOIN LATERAL (
+  VALUES
+  ('3', 'Quarry dust', 'Trucks', 1, 30000, 2),
+  ('4', 'Rock sand', 'Trucks', 2, 30000, 3),
+  ('5', 'Cutting discs', 'Pcs', 5, 500, 4),
+  ('6', 'D.P.M', 'Rolls', 1, 5000, 5)
+) AS item(item_number, description, unit, qty, rate, sort_order)
+WHERE NOT EXISTS (
+  SELECT 1 FROM lcl_template_items li
+  WHERE li.structure_id = s.id
+  AND li.section_id = 'section_c'
+  AND li.subsection_id = 'section_c_materials'
+  AND li.description = item.description
+);
+
+-- =========================================================
+-- End of script
+-- =========================================================

--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -15,7 +15,7 @@ interface ConfirmationDialogProps {
   title: string;
   description?: string;
   onConfirm: () => void | Promise<void>;
-  onCancel: () => void;
+  onCancel?: () => void;
   isLoading?: boolean;
   confirmText?: string;
   cancelText?: string;
@@ -37,7 +37,7 @@ export function ConfirmationDialog({
 }: ConfirmationDialogProps) {
   return (
     <AlertDialog open={open} onOpenChange={(isOpen) => {
-      if (!isOpen && onCancel && typeof onCancel === 'function') {
+      if (!isOpen && typeof onCancel === 'function') {
         onCancel();
       }
     }}>

--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -37,7 +37,9 @@ export function ConfirmationDialog({
 }: ConfirmationDialogProps) {
   return (
     <AlertDialog open={open} onOpenChange={(isOpen) => {
-      if (!isOpen) onCancel();
+      if (!isOpen && onCancel && typeof onCancel === 'function') {
+        onCancel();
+      }
     }}>
       <AlertDialogContent>
         <AlertDialogHeader>

--- a/src/pages/LCLBOQList.tsx
+++ b/src/pages/LCLBOQList.tsx
@@ -286,12 +286,11 @@ export default function LCLBOQList() {
 
       <ConfirmationDialog
         open={showDeleteConfirm !== null}
-        onOpenChange={(open) => !open && setShowDeleteConfirm(null)}
+        onCancel={() => setShowDeleteConfirm(null)}
         title="Delete LCL BOQ"
         description="Are you sure you want to delete this LCL BOQ? This action cannot be undone."
         onConfirm={handleConfirmDelete}
         confirmText="Delete"
-        confirmVariant="destructive"
       />
     </div>
   );

--- a/src/utils/lclBoqPdfGenerator.ts
+++ b/src/utils/lclBoqPdfGenerator.ts
@@ -30,10 +30,13 @@ function flattenLCLBOQItems(data: LCLHierarchicalData): Array<{
     _isSubtotal?: boolean;
   }> = [];
 
-  data.sections.forEach((section) => {
-    // Add section header
+  data.sections.forEach((section, sectionIndex) => {
+    // Generate section letter (A, B, C, etc.)
+    const sectionLetter = String.fromCharCode(65 + sectionIndex);
+
+    // Add section header with proper format for PDF renderer
     flatItems.push({
-      description: section.section_name,
+      description: `SECTION ${sectionLetter}: ${section.section_name}`,
       quantity: 0,
       unit_price: 0,
       line_total: 0,


### PR DESCRIPTION
### Summary
Fixes a runtime error in the `ConfirmationDialog` component caused by an always-required `onCancel` prop, and adds missing BOQ template items and section headers to the LCL BOQ PDF output.

### Problem
The `ConfirmationDialog` component required `onCancel` as a mandatory prop, causing a runtime error when it was not provided. Additionally, the LCL BOQ PDF was missing section headers (e.g., "SECTION A: Foundation"), and several template items were absent from Sections A, B, and C of the default BOQ structure.

### Solution
- Made `onCancel` optional in `ConfirmationDialog` and guarded its invocation with a type check.
- Updated the PDF generator to prepend a formatted section letter (A, B, C…) to each section header.
- Added a new SQL migration script to insert the missing BOQ template items across all three sections and renumber existing items accordingly.

### Key Changes
- **`ConfirmationDialog.tsx`**: Made `onCancel` prop optional (`onCancel?: () => void`) and wrapped its call in a `typeof onCancel === 'function'` guard to prevent the runtime error.
- **`LCLBOQList.tsx`**: Updated `ConfirmationDialog` usage to pass `onCancel` instead of the non-existent `onOpenChange` prop; removed unused `confirmVariant` prop.
- **`lclBoqPdfGenerator.ts`**: Section headers now render as `SECTION A: Foundation`, `SECTION B: Ground Floor Walling`, etc., using a derived section letter.
- **`db-scripts/add-lcl-boq-items.sql`** (new): Migration script that:
  - Renumbers existing Section A materials to make room, then inserts Quarry Dust, Rock Sand, and D20 before D16.
  - Renumbers existing Section B materials and inserts Machine-cut 6x9, Quarry dust, Rock sand, D20, D16, D12, D10, and D8.
  - Updates "Riversand" to "Sand" in Section C and inserts Quarry dust, Rock sand, Cutting discs, and D.P.M.


---

<a href="https://builder.io/app/projects/e7cdd28f34dd4181bef5/silk-segment-yt2oslck"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://e7cdd28f34dd4181bef5-silk-segment-yt2oslck_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=e7cdd28f34dd4181bef5&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 266`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e7cdd28f34dd4181bef5</projectId>-->
<!--<branchName>silk-segment-yt2oslck</branchName>-->