### PR TITLE
Remove autosave and fix BOQ save in EditLCLBOQModal

### DIFF
--- a/src/components/lcl/EditLCLBOQModal.tsx
+++ b/src/components/lcl/EditLCLBOQModal.tsx
@@ -266,6 +266,18 @@ export function EditLCLBOQModal({
     setSaving(true);
     setSaveStatus('saving');
     try {
+      // Step 1: Validate boq.id exists before attempting save
+      if (!boq.id) {
+        console.error('CRITICAL: Cannot save BOQ - ID is missing', { boq });
+        throw new Error('Cannot save: BOQ ID is missing. This is a critical data issue. Please reload and try again.');
+      }
+
+      console.log('Starting BOQ save', {
+        boqId: boq.id,
+        editsCount: Object.keys(inlineEdits).length,
+        itemsCount: items.length
+      });
+
       // Apply all inline edits to items
       const updatedItems = items.map((item, idx) => {
         const itemId = `item-${idx}`;
@@ -284,10 +296,23 @@ export function EditLCLBOQModal({
         return item;
       });
 
-      await lclBoqService.saveLCLBOQ({
+      const savePayload = {
         ...boq,
         items_snapshot: updatedItems,
         updated_at: new Date().toISOString(),
+      };
+
+      console.log('Save payload prepared', {
+        id: savePayload.id,
+        itemsCount: updatedItems.length,
+        sampleItem: updatedItems[0]
+      });
+
+      const result = await lclBoqService.saveLCLBOQ(savePayload);
+
+      console.log('Save completed successfully', {
+        resultId: result.id,
+        updatedAt: result.updated_at
       });
 
       setItems(updatedItems);

--- a/src/components/lcl/EditLCLBOQModal.tsx
+++ b/src/components/lcl/EditLCLBOQModal.tsx
@@ -58,12 +58,10 @@ export function EditLCLBOQModal({
   const [items, setItems] = useState<ItemSnapshot[]>([]);
   const [inlineEdits, setInlineEdits] = useState<{ [itemId: string]: InlineEdit }>({});
   const [saving, setSaving] = useState(false);
-  const [saveStatus, setSaveStatus] = useState<'saved' | 'unsaved' | 'saving' | null>(null);
+  const [saveStatus, setSaveStatus] = useState<'unsaved' | 'saving' | null>(null);
   const [activeSection, setActiveSection] = useState<string | null>(null);
   const [downloading, setDownloading] = useState(false);
-  const debounceTimers = useRef<{ [itemId: string]: NodeJS.Timeout }>({});
   const inlineEditsRef = useRef<{ [itemId: string]: InlineEdit }>({});
-  const isMountedRef = useRef(true);
   const { toast } = useToast();
   const { currentCompany } = useCurrentCompany();
   const { data: customers } = useCustomers(currentCompany?.id || '');
@@ -149,7 +147,6 @@ export function EditLCLBOQModal({
       setItems(boq.items_snapshot);
       setInlineEdits({});
       inlineEditsRef.current = {};
-      setSaveStatus(null);
       const sections = extractSections(boq.items_snapshot);
       if (sections.length > 0) {
         setActiveSection(sections[0]);
@@ -161,12 +158,6 @@ export function EditLCLBOQModal({
     inlineEditsRef.current = inlineEdits;
   }, [inlineEdits]);
 
-  useEffect(() => {
-    return () => {
-      isMountedRef.current = false;
-      Object.values(debounceTimers.current).forEach((timer) => clearTimeout(timer));
-    };
-  }, []);
 
   const getItemAmount = (item: ItemSnapshot, itemIndex: number): number => {
     const itemId = `item-${itemIndex}`;
@@ -196,14 +187,6 @@ export function EditLCLBOQModal({
       [itemId]: { ...prev[itemId], qty: finalQty },
     }));
     setSaveStatus('unsaved');
-
-    if (debounceTimers.current[itemId]) {
-      clearTimeout(debounceTimers.current[itemId]);
-    }
-
-    debounceTimers.current[itemId] = setTimeout(() => {
-      saveInlineEdit(itemIndex);
-    }, 500);
   };
 
   const handleRateChange = (itemIndex: number, value: string) => {
@@ -218,14 +201,6 @@ export function EditLCLBOQModal({
       [itemId]: { ...prev[itemId], rate: finalRate },
     }));
     setSaveStatus('unsaved');
-
-    if (debounceTimers.current[itemId]) {
-      clearTimeout(debounceTimers.current[itemId]);
-    }
-
-    debounceTimers.current[itemId] = setTimeout(() => {
-      saveInlineEdit(itemIndex);
-    }, 500);
   };
 
   const handleDescriptionChange = (itemIndex: number, value: string) => {
@@ -235,81 +210,8 @@ export function EditLCLBOQModal({
       [itemId]: { ...prev[itemId], description: value },
     }));
     setSaveStatus('unsaved');
-
-    if (debounceTimers.current[itemId]) {
-      clearTimeout(debounceTimers.current[itemId]);
-    }
-
-    debounceTimers.current[itemId] = setTimeout(() => {
-      saveInlineEdit(itemIndex);
-    }, 500);
   };
 
-  const saveInlineEdit = async (itemIndex: number) => {
-    if (!isMountedRef.current) return;
-
-    setSaveStatus('saving');
-    try {
-      const itemId = `item-${itemIndex}`;
-      const edit = inlineEditsRef.current[itemId];
-
-      // Only save if there are actual edits for this item
-      if (!edit) {
-        if (isMountedRef.current) {
-          setSaveStatus('saved');
-        }
-        return;
-      }
-
-      const currentItem = items[itemIndex];
-      const qty = edit.qty !== undefined ? edit.qty : currentItem.qty;
-      const rate = edit.rate !== undefined ? edit.rate : currentItem.rate;
-      const description = edit.description !== undefined ? edit.description : currentItem.description;
-
-      const updatedItems = items.map((item, idx) => {
-        if (idx === itemIndex) {
-          return {
-            ...item,
-            qty,
-            rate,
-            description,
-            amount: qty * rate,
-          };
-        }
-        return item;
-      });
-
-      await lclBoqService.saveLCLBOQ({
-        ...boq,
-        items_snapshot: updatedItems,
-        updated_at: new Date().toISOString(),
-      });
-
-      if (!isMountedRef.current) return;
-
-      setItems(updatedItems);
-
-      // Clear the inline edits for this item only after successful save
-      setInlineEdits((prev) => {
-        const updated = { ...prev };
-        delete updated[itemId];
-        return updated;
-      });
-
-      setSaveStatus('saved');
-    } catch (error) {
-      if (!isMountedRef.current) return;
-
-      console.error('Error saving edit:', error);
-      setSaveStatus('unsaved');
-      toast({
-        title: 'Error',
-        description:
-          error instanceof Error ? error.message : 'Failed to save changes',
-        variant: 'destructive',
-      });
-    }
-  };
 
   const handleDownloadPDF = async () => {
     setDownloading(true);
@@ -355,15 +257,16 @@ export function EditLCLBOQModal({
   };
 
   const handleSaveAll = async () => {
-    // If all changes are already saved, just close
-    if (saveStatus === 'saved' && Object.keys(inlineEdits).length === 0) {
+    // If no unsaved changes, just close
+    if (Object.keys(inlineEdits).length === 0) {
       onClose();
       return;
     }
 
     setSaving(true);
+    setSaveStatus('saving');
     try {
-      // Apply any remaining unsaved inline edits to items
+      // Apply all inline edits to items
       const updatedItems = items.map((item, idx) => {
         const itemId = `item-${idx}`;
         const edit = inlineEdits[itemId];
@@ -381,17 +284,16 @@ export function EditLCLBOQModal({
         return item;
       });
 
-      // Only save if there are unsaved changes
-      if (Object.keys(inlineEdits).length > 0) {
-        await lclBoqService.saveLCLBOQ({
-          ...boq,
-          items_snapshot: updatedItems,
-          updated_at: new Date().toISOString(),
-        });
-      }
+      await lclBoqService.saveLCLBOQ({
+        ...boq,
+        items_snapshot: updatedItems,
+        updated_at: new Date().toISOString(),
+      });
 
+      setItems(updatedItems);
       setInlineEdits({});
-      setSaveStatus('saved');
+      inlineEditsRef.current = {};
+
       toast({
         title: 'Success',
         description: 'BOQ updated successfully',
@@ -400,6 +302,7 @@ export function EditLCLBOQModal({
       onClose();
     } catch (error) {
       console.error('Error saving BOQ:', error);
+      setSaveStatus('unsaved');
       toast({
         title: 'Error',
         description:
@@ -461,32 +364,10 @@ export function EditLCLBOQModal({
         )}
 
         <div className="space-y-4">
-          {saveStatus && (
-            <div
-              className={`flex items-center gap-2 p-3 rounded text-sm ${
-                saveStatus === 'saving'
-                  ? 'bg-blue-50 text-blue-900'
-                  : saveStatus === 'saved'
-                    ? 'bg-green-50 text-green-900'
-                    : 'bg-yellow-50 text-yellow-900'
-              }`}
-            >
-              {saveStatus === 'saved' ? (
-                <>
-                  <CheckCircle2 className="h-4 w-4" />
-                  <span>All changes saved</span>
-                </>
-              ) : saveStatus === 'saving' ? (
-                <>
-                  <AlertCircle className="h-4 w-4 animate-spin" />
-                  <span>Saving...</span>
-                </>
-              ) : (
-                <>
-                  <AlertCircle className="h-4 w-4" />
-                  <span>Unsaved changes</span>
-                </>
-              )}
+          {saveStatus === 'unsaved' && (
+            <div className="flex items-center gap-2 p-3 rounded text-sm bg-yellow-50 text-yellow-900">
+              <AlertCircle className="h-4 w-4" />
+              <span>Unsaved changes</span>
             </div>
           )}
 
@@ -589,7 +470,7 @@ export function EditLCLBOQModal({
           </Button>
           <Button
             onClick={handleSaveAll}
-            disabled={saving || saveStatus === 'saved'}
+            disabled={saving || Object.keys(inlineEdits).length === 0}
           >
             {saving ? 'Saving...' : 'Save All Changes'}
           </Button>

--- a/src/components/lcl/EditLCLBOQModal.tsx
+++ b/src/components/lcl/EditLCLBOQModal.tsx
@@ -63,6 +63,7 @@ export function EditLCLBOQModal({
   const [downloading, setDownloading] = useState(false);
   const debounceTimers = useRef<{ [itemId: string]: NodeJS.Timeout }>({});
   const inlineEditsRef = useRef<{ [itemId: string]: InlineEdit }>({});
+  const isMountedRef = useRef(true);
   const { toast } = useToast();
   const { currentCompany } = useCurrentCompany();
   const { data: customers } = useCustomers(currentCompany?.id || '');
@@ -162,6 +163,7 @@ export function EditLCLBOQModal({
 
   useEffect(() => {
     return () => {
+      isMountedRef.current = false;
       Object.values(debounceTimers.current).forEach((timer) => clearTimeout(timer));
     };
   }, []);
@@ -200,13 +202,7 @@ export function EditLCLBOQModal({
     }
 
     debounceTimers.current[itemId] = setTimeout(() => {
-      const freshEdit = inlineEditsRef.current[itemId] || {};
-      saveInlineEdit(
-        itemIndex,
-        freshEdit.qty,
-        freshEdit.rate,
-        freshEdit.description
-      );
+      saveInlineEdit(itemIndex);
     }, 500);
   };
 
@@ -228,13 +224,7 @@ export function EditLCLBOQModal({
     }
 
     debounceTimers.current[itemId] = setTimeout(() => {
-      const freshEdit = inlineEditsRef.current[itemId] || {};
-      saveInlineEdit(
-        itemIndex,
-        freshEdit.qty,
-        freshEdit.rate,
-        freshEdit.description
-      );
+      saveInlineEdit(itemIndex);
     }, 500);
   };
 
@@ -251,33 +241,33 @@ export function EditLCLBOQModal({
     }
 
     debounceTimers.current[itemId] = setTimeout(() => {
-      const freshEdit = inlineEditsRef.current[itemId] || {};
-      saveInlineEdit(
-        itemIndex,
-        freshEdit.qty,
-        freshEdit.rate,
-        freshEdit.description
-      );
+      saveInlineEdit(itemIndex);
     }, 500);
   };
 
-  const saveInlineEdit = async (
-    itemIndex: number,
-    newQty?: number,
-    newRate?: number,
-    newDescription?: string
-  ) => {
+  const saveInlineEdit = async (itemIndex: number) => {
+    if (!isMountedRef.current) return;
+
     setSaveStatus('saving');
     try {
       const itemId = `item-${itemIndex}`;
+      const edit = inlineEditsRef.current[itemId];
+
+      // Only save if there are actual edits for this item
+      if (!edit) {
+        if (isMountedRef.current) {
+          setSaveStatus('saved');
+        }
+        return;
+      }
+
       const currentItem = items[itemIndex];
-      const edit = inlineEditsRef.current[itemId] || {};
+      const qty = edit.qty !== undefined ? edit.qty : currentItem.qty;
+      const rate = edit.rate !== undefined ? edit.rate : currentItem.rate;
+      const description = edit.description !== undefined ? edit.description : currentItem.description;
 
       const updatedItems = items.map((item, idx) => {
         if (idx === itemIndex) {
-          const qty = edit.qty !== undefined ? edit.qty : item.qty;
-          const rate = edit.rate !== undefined ? edit.rate : item.rate;
-          const description = edit.description !== undefined ? edit.description : item.description;
           return {
             ...item,
             qty,
@@ -295,6 +285,8 @@ export function EditLCLBOQModal({
         updated_at: new Date().toISOString(),
       });
 
+      if (!isMountedRef.current) return;
+
       setItems(updatedItems);
 
       // Clear the inline edits for this item only after successful save
@@ -306,6 +298,8 @@ export function EditLCLBOQModal({
 
       setSaveStatus('saved');
     } catch (error) {
+      if (!isMountedRef.current) return;
+
       console.error('Error saving edit:', error);
       setSaveStatus('unsaved');
       toast({

--- a/src/services/lclBoqService.ts
+++ b/src/services/lclBoqService.ts
@@ -52,8 +52,11 @@ class LCLBOQService {
   async saveLCLBOQ(boq: LCLBOQRecord): Promise<LCLBOQRecord> {
     const { id, ...data } = boq;
 
+    console.log('saveLCLBOQ called', { id, hasId: !!id, dataKeys: Object.keys(data) });
+
     if (id) {
       // Update existing
+      console.log('Performing UPDATE on lcl_boqs', { id });
       const { data: updated, error } = await supabase
         .from('lcl_boqs')
         .update({
@@ -64,10 +67,16 @@ class LCLBOQService {
         .select()
         .single();
 
-      if (error) throw error;
+      if (error) {
+        console.error('UPDATE error on lcl_boqs', { id, error });
+        throw error;
+      }
+
+      console.log('UPDATE successful', { id, updatedId: updated?.id, updatedAt: updated?.updated_at });
       return updated as LCLBOQRecord;
     } else {
       // Create new
+      console.log('Performing INSERT on lcl_boqs (no id provided)');
       const { data: created, error } = await supabase
         .from('lcl_boqs')
         .insert({
@@ -78,7 +87,12 @@ class LCLBOQService {
         .select()
         .single();
 
-      if (error) throw error;
+      if (error) {
+        console.error('INSERT error on lcl_boqs', { error });
+        throw error;
+      }
+
+      console.log('INSERT successful', { createdId: created?.id });
       return created as LCLBOQRecord;
     }
   }


### PR DESCRIPTION
### Summary
Removes the broken autosave (debounce) mechanism from `EditLCLBOQModal` and consolidates all edits into a single explicit "Save All Changes" action, fixing values reverting after appearing to save successfully.

### Problem
When editing qty/rate/description fields in `EditLCLBOQModal`, the autosave debounce timers were capturing stale closure values. If a user edited qty and then rate within 500ms, the debounced save for qty would fire with the old rate value (and vice versa), causing race conditions where partially stale data was written to the database. The UI would show "All changes saved" while the database received incorrect or outdated values. On refresh, the old values would reappear.

### Solution
Removed all debounce-based autosave logic entirely. Changes are now only persisted when the user explicitly clicks "Save All Changes", which applies all accumulated `inlineEdits` in a single, consistent save operation. Additional validation and logging were added to the save path to catch and surface issues (e.g., missing BOQ ID).

### Key Changes
- **Removed autosave debounce**: Deleted `debounceTimers` ref, all `setTimeout`/`clearTimeout` logic, and the `saveInlineEdit()` function from `EditLCLBOQModal.tsx`
- **Simplified `handleSaveAll`**: Now applies all pending `inlineEdits` to items in one pass and performs a single `saveLCLBOQ` call; updates local state only after a confirmed successful save
- **BOQ ID validation**: Added an explicit check for `boq.id` before attempting a save, throwing a clear error if it is missing
- **Simplified save status**: Removed the `'saved'` state from `saveStatus`; the banner now only shows when there are unsaved changes (`'unsaved'`), and the save button is disabled when `inlineEdits` is empty
- **Cleanup**: Removed the unmount effect that cleared debounce timers (no longer needed)
- **Enhanced logging in `lclBoqService.ts`**: Added `console.log`/`console.error` statements around the Supabase `UPDATE` and `INSERT` calls to aid in diagnosing future save failures


---

<a href="https://builder.io/app/projects/0a47c1253525465c96cd/hemi-guild-ubrlmmtu"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://0a47c1253525465c96cd-hemi-guild-ubrlmmtu_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=0a47c1253525465c96cd&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 271`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0a47c1253525465c96cd</projectId>-->
<!--<branchName>hemi-guild-ubrlmmtu</branchName>-->