### PR TITLE
Update LCL BOQ template and edit modal display

### DIFF
--- a/src/components/lcl/EditLCLBOQModal.tsx
+++ b/src/components/lcl/EditLCLBOQModal.tsx
@@ -354,6 +354,11 @@ export function EditLCLBOQModal({
                   Section {activeSection}
                 </p>
               )}
+              {boq.id && (
+                <p className="text-sm text-muted-foreground mt-1">
+                  editng LCL id {boq.id}
+                </p>
+              )}
             </div>
             <Button
               size="sm"

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -138,11 +138,21 @@ export class LCLTemplateService {
     // Fetch all items for this structure
     const items = await this.getStructureItems(structureId);
 
+    // Deduplicate sections to prevent duplicate key errors
+    const seenSectionIds = new Set<string>();
+    const uniqueSections = structure.structure_data.sections.filter((section: any) => {
+      if (seenSectionIds.has(section.id)) {
+        return false;
+      }
+      seenSectionIds.add(section.id);
+      return true;
+    });
+
     // Build hierarchical view
     const sections: LCLSectionWithSubsections[] = [];
     let grand_total = 0;
 
-    for (const sectionDef of structure.structure_data.sections) {
+    for (const sectionDef of uniqueSections) {
       const subsections: LCLSubsectionWithItems[] = [];
       let section_total = 0;
 

--- a/supabase/migrations/20250527_seed_lcl_default_boq.sql
+++ b/supabase/migrations/20250527_seed_lcl_default_boq.sql
@@ -135,7 +135,7 @@ LATERAL (
   SELECT 'section_a', 'section_a_labor', '11', 'Foundation Slab Concreting', 'Item', 1, 28000, 10 UNION ALL
   
   -- SECTION B: GROUND FLOOR WALLING - MATERIALS
-  SELECT 'section_b', 'section_b_materials', '1', 'Machine Cut Stones 9 by 9', 'Pcs', 2800, 60, 0 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '1', 'Machine Cut Stones 6 by 9', 'Pcs', 2800, 60, 0 UNION ALL
   SELECT 'section_b', 'section_b_materials', '2', 'Machine-cut 6x9', 'Pcs', 100, 60, 1 UNION ALL
   SELECT 'section_b', 'section_b_materials', '3', 'Quarry dust', 'Trucks', 1, 30000, 2 UNION ALL
   SELECT 'section_b', 'section_b_materials', '4', 'Rock sand', 'Trucks', 2, 30000, 3 UNION ALL

--- a/supabase/migrations/20250527_seed_lcl_default_boq.sql
+++ b/supabase/migrations/20250527_seed_lcl_default_boq.sql
@@ -1,195 +1,211 @@
--- Seed LCL Default BOQ structure with data from BOQ-085 (PROPOSED RESIDENTIAL MAISONETTE)
--- This migration creates a default LCL BOQ structure and populates it with all items from the PDF
+-- =========================================================
+-- SEED LCL DEFAULT BOQ STRUCTURE
+-- =========================================================
 
--- Insert a special LCL BOQ structure (per company)
--- Note: This assumes a function or trigger will auto-create this for each company, or we seed it once globally
--- For now, we'll create a migration-friendly approach using a placeholder company_id
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
--- Structure definition with sections A-G
+-- =========================================================
+-- CREATE DEFAULT STRUCTURES PER COMPANY
+-- =========================================================
+
 INSERT INTO lcl_template_structures (
-  company_id,
-  name,
-  description,
-  structure_data,
-  is_active,
-  created_at,
-  updated_at
-) 
-SELECT 
-  companies.id,
-  'LCL Default BOQ',
-  'Default BOQ structure for Layons Construction projects (BOQ-085: Proposed Residential Maisonette)',
-  jsonb_build_object(
-    'sections', jsonb_build_array(
-      jsonb_build_object('id', 'section_a', 'name', 'Section A: Foundation', 'subsections', jsonb_build_array(
-        jsonb_build_object('id', 'section_a_materials', 'name', 'Materials'),
-        jsonb_build_object('id', 'section_a_labor', 'name', 'Labor')
-      )),
-      jsonb_build_object('id', 'section_b', 'name', 'Section B: Ground Floor Walling', 'subsections', jsonb_build_array(
-        jsonb_build_object('id', 'section_b_materials', 'name', 'Materials'),
-        jsonb_build_object('id', 'section_b_labor', 'name', 'Labor')
-      )),
-      jsonb_build_object('id', 'section_c', 'name', 'Section C: Ground Floor Suspended Slab', 'subsections', jsonb_build_array(
-        jsonb_build_object('id', 'section_c_materials', 'name', 'Materials'),
-        jsonb_build_object('id', 'section_c_labor', 'name', 'Labor')
-      )),
-      jsonb_build_object('id', 'section_d', 'name', 'Section D: First Floor Walling and Columns', 'parent_section_id', 'section_b', 'subsections', jsonb_build_array(
-        jsonb_build_object('id', 'section_d_materials', 'name', 'Materials'),
-        jsonb_build_object('id', 'section_d_labor', 'name', 'Labor')
-      )),
-      jsonb_build_object('id', 'section_e', 'name', 'Section E: First Floor Suspended Slab', 'parent_section_id', 'section_c', 'subsections', jsonb_build_array(
-        jsonb_build_object('id', 'section_e_materials', 'name', 'Materials'),
-        jsonb_build_object('id', 'section_e_labor', 'name', 'Labor')
-      )),
-      jsonb_build_object('id', 'section_f', 'name', 'Section F: Second Floor Walling and Columns', 'parent_section_id', 'section_b', 'subsections', jsonb_build_array(
-        jsonb_build_object('id', 'section_f_materials', 'name', 'Materials'),
-        jsonb_build_object('id', 'section_f_labor', 'name', 'Labor')
-      )),
-      jsonb_build_object('id', 'section_g', 'name', 'Section G: Second Floor Suspended Slab', 'parent_section_id', 'section_c', 'subsections', jsonb_build_array(
-        jsonb_build_object('id', 'section_g_materials', 'name', 'Materials'),
-        jsonb_build_object('id', 'section_g_labor', 'name', 'Labor')
-      ))
-    )
-  ),
-  true,
-  NOW(),
-  NOW()
-FROM companies
-WHERE NOT EXISTS (
-  SELECT 1 FROM lcl_template_structures 
-  WHERE name = 'LCL Default BOQ' AND company_id = companies.id
+    company_id,
+    name,
+    description,
+    structure_data,
+    is_active,
+    created_at,
+    updated_at
 )
-ON CONFLICT DO NOTHING;
+SELECT
+    c.id,
+    'LCL Default BOQ',
+    'Default BOQ structure for Layons Construction projects (BOQ-085: Proposed Residential Maisonette)',
+    
+    jsonb_build_object(
+        'sections',
+        jsonb_build_array(
 
--- Helper: Get the default LCL structure IDs by company
-WITH lcl_structures AS (
-  SELECT id, company_id FROM lcl_template_structures 
-  WHERE name = 'LCL Default BOQ'
-)
-INSERT INTO lcl_template_items (
-  company_id,
-  structure_id,
-  section_id,
-  subsection_id,
-  item_number,
-  description,
-  unit,
-  default_qty,
-  default_rate,
-  sort_order,
-  created_at,
-  updated_at
-)
-SELECT 
-  s.company_id,
-  s.id,
-  item.section_id,
-  item.subsection_id,
-  item.item_number,
-  item.description,
-  item.unit,
-  item.qty,
-  item.rate,
-  item.sort_order,
-  NOW(),
-  NOW()
-FROM lcl_structures s,
-LATERAL (
-  -- SECTION A: FOUNDATION - MATERIALS
-  SELECT 'section_a', 'section_a_materials', '1', 'Ballast', 'Trucks', 7, 30000, 0 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '2', 'Sand', 'Trucks', 8, 30000, 1 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '3', 'Cement', 'Bags', 230, 850, 2 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '4', 'Quarry dust', 'Trucks', 20, 2180, 3 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '5', 'Rock sand', 'Trucks', 2, 30000, 4 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '6', 'D20', 'Pcs', 5, 2700, 5 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '7', 'D12', 'Pcs', 30, 1190, 6 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '8', 'D10', 'Pcs', 62, 825, 7 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '9', 'D8', 'Pcs', 80, 530, 8 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '10', 'Binding Wire', 'Rolls', 3, 2700, 9 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '11', 'Hacksaw Blades', 'Pcs', 10, 100, 10 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '12', 'Nails 3"', 'Kgs', 20, 180, 11 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '13', 'Nails 4"', 'Kgs', 20, 180, 12 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '14', 'Foundation Stones', 'Ft', 2800, 60, 13 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '15', 'Hoop Iron', 'Pcs', 8, 1500, 14 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '16', 'Hardcore/Murram', 'Trucks', 14, 6000, 15 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '17', 'D.p.m', 'Rolls', 8, 1500, 16 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '18', 'B.r.c A98', 'Rolls', 3, 19000, 17 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '19', 'Plumbing Items', 'Item', 1, 10000, 18 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '20', 'Termite Treatment', 'Ltrs', 2, 1200, 19 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '21', 'Timber 6 by 1', 'Ft', 800, 25, 20 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '22', 'Profiles', 'Pcs', 40, 200, 21 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '23', 'White Wash 25kg', 'Bags', 2, 250, 22 UNION ALL
-  SELECT 'section_a', 'section_a_materials', '24', 'Setting Out Lines', 'Pcs', 10, 60, 23 UNION ALL
-  
-  -- SECTION A: FOUNDATION - LABOR
-  SELECT 'section_a', 'section_a_labor', '1', 'Setting Out', 'Item', 1, 6000, 0 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '3', 'Excavation & Levelling', 'Item', 1, 40000, 2 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '4', 'Bases & Trenches Concreting', 'Item', 1, 24000, 3 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '5', 'Masonry Works', 'Item', 1, 120000, 4 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '6', 'Formwork', 'Item', 1, 8000, 5 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '7', 'Column Concreting', 'Item', 1, 14000, 6 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '8', 'Backfilling & Compaction', 'Item', 1, 22000, 7 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '9', 'Laying Of D.p.m, Termite Treatment & Laying of B.r.c', 'Item', 1, 6000, 8 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '10', 'Plumbing Works', 'Item', 1, 8000, 9 UNION ALL
-  SELECT 'section_a', 'section_a_labor', '11', 'Foundation Slab Concreting', 'Item', 1, 28000, 10 UNION ALL
-  
-  -- SECTION B: GROUND FLOOR WALLING - MATERIALS
-  SELECT 'section_b', 'section_b_materials', '1', 'Machine Cut Stones 6 by 9', 'Pcs', 2800, 60, 0 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '2', 'Machine-cut 6x9', 'Pcs', 100, 60, 1 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '3', 'Quarry dust', 'Trucks', 1, 30000, 2 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '4', 'Rock sand', 'Trucks', 2, 30000, 3 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '5', 'Sand', 'Trucks', 2, 30000, 4 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '6', 'Cement', 'Bags', 90, 850, 5 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '7', 'D20', 'Pcs', 5, 2700, 6 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '8', 'D16', 'Pcs', 27, 2180, 7 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '9', 'D12', 'Pcs', 15, 1190, 8 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '10', 'D10', 'Pcs', 20, 825, 9 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '11', 'D8', 'Pcs', 20, 530, 10 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '12', 'Binding Wire', 'Rolls', 1, 2700, 11 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '13', 'Hacksaw Blades', 'Pcs', 10, 100, 12 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '14', 'Timber 6x1', 'Ft', 1000, 25, 13 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '15', 'Nails 3"', 'Kgs', 5, 180, 14 UNION ALL
-  SELECT 'section_b', 'section_b_materials', '16', 'Nails 4"', 'Kgs', 5, 180, 15 UNION ALL
-  
-  -- SECTION B: GROUND FLOOR WALLING - LABOR
-  SELECT 'section_b', 'section_b_labor', '1', 'Setting & Levelling', 'Item', 1, 12000, 0 UNION ALL
-  SELECT 'section_b', 'section_b_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1 UNION ALL
-  SELECT 'section_b', 'section_b_labor', '3', 'Masonry works', 'Item', 1, 140000, 2 UNION ALL
-  SELECT 'section_b', 'section_b_labor', '4', 'Column Formwork', 'Item', 1, 12000, 3 UNION ALL
-  SELECT 'section_b', 'section_b_labor', '5', 'Column Concreting', 'Item', 1, 16000, 4 UNION ALL
-  
-  -- SECTION C: GROUND FLOOR SUSPENDED SLAB - MATERIALS
-  SELECT 'section_c', 'section_c_materials', '1', 'Quarry dust', 'Trucks', 1, 30000, 0 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '2', 'Rock sand', 'Trucks', 2, 30000, 1 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '3', 'Timber 3x2', 'Ft', 2000, 25, 2 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '4', 'Timber 6x1', 'Ft', 1500, 25, 3 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '5', 'Profiles', 'Pcs', 250, 180, 4 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '6', 'Trappers', 'Pcs', 180, 120, 5 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '7', 'Nails 4"', 'Bags', 1, 8000, 6 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '8', 'Nails 3"', 'Bags', 1, 8000, 7 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '9', 'D16', 'Pcs', 12, 2180, 8 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '10', 'D12', 'Pcs', 70, 1190, 9 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '11', 'D10', 'Pcs', 320, 825, 10 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '12', 'D8', 'Pcs', 90, 530, 11 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '13', 'Binding Wire', 'Rolls', 5, 2700, 12 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '14', 'Blades', 'Pcs', 20, 100, 13 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '15', 'Cutting disks', 'Pcs', 10, 150, 14 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '16', 'D.P.M', 'Rolls', 8, 1500, 15 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '17', 'Ballast', 'Trucks', 6, 30000, 16 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '18', 'Cement', 'Bags', 180, 850, 17 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '19', 'Electrical Items', 'Item', 1, 15000, 18 UNION ALL
-  SELECT 'section_c', 'section_c_materials', '20', 'Plumbing Items', 'Item', 1, 10000, 19 UNION ALL
-  
-  -- SECTION C: GROUND FLOOR SUSPENDED SLAB - LABOR
-  SELECT 'section_c', 'section_c_labor', '1', 'Formwork', 'Item', 1, 70000, 0 UNION ALL
-  SELECT 'section_c', 'section_c_labor', '2', 'Bar Bending', 'Item', 1, 60000, 1 UNION ALL
-  SELECT 'section_c', 'section_c_labor', '3', 'Electrical Works', 'Item', 1, 18000, 2 UNION ALL
-  SELECT 'section_c', 'section_c_labor', '4', 'Plumbing Works', 'Item', 1, 10000, 3 UNION ALL
-  SELECT 'section_c', 'section_c_labor', '5', 'Concreting', 'Item', 1, 40000, 4 UNION ALL
-  
-) AS item(section_id, subsection_id, item_number, description, unit, qty, rate, sort_order)
+            jsonb_build_object(
+                'id', 'section_a',
+                'name', 'Section A: Foundation',
+                'subsections', jsonb_build_array(
+                    jsonb_build_object(
+                        'id', 'section_a_materials',
+                        'name', 'Materials'
+                    ),
+                    jsonb_build_object(
+                        'id', 'section_a_labor',
+                        'name', 'Labor'
+                    )
+                )
+            ),
+
+            jsonb_build_object(
+                'id', 'section_b',
+                'name', 'Section B: Ground Floor Walling',
+                'subsections', jsonb_build_array(
+                    jsonb_build_object(
+                        'id', 'section_b_materials',
+                        'name', 'Materials'
+                    ),
+                    jsonb_build_object(
+                        'id', 'section_b_labor',
+                        'name', 'Labor'
+                    )
+                )
+            ),
+
+            jsonb_build_object(
+                'id', 'section_c',
+                'name', 'Section C: Ground Floor Suspended Slab',
+                'subsections', jsonb_build_array(
+                    jsonb_build_object(
+                        'id', 'section_c_materials',
+                        'name', 'Materials'
+                    ),
+                    jsonb_build_object(
+                        'id', 'section_c_labor',
+                        'name', 'Labor'
+                    )
+                )
+            )
+
+        )
+    ),
+
+    true,
+    NOW(),
+    NOW()
+
+FROM companies c
+
 WHERE NOT EXISTS (
-  SELECT 1 FROM lcl_template_items 
-  WHERE structure_id = s.id AND section_id = item.section_id AND subsection_id = item.subsection_id AND item_number = item.item_number
+    SELECT 1
+    FROM lcl_template_structures lts
+    WHERE lts.company_id = c.id
+      AND lts.name = 'LCL Default BOQ'
+);
+
+-- =========================================================
+-- INSERT TEMPLATE ITEMS
+-- =========================================================
+
+WITH lcl_structures AS (
+    SELECT
+        id,
+        company_id
+    FROM lcl_template_structures
+    WHERE name = 'LCL Default BOQ'
+)
+
+INSERT INTO lcl_template_items (
+    company_id,
+    structure_id,
+    section_id,
+    subsection_id,
+    item_number,
+    description,
+    unit,
+    default_qty,
+    default_rate,
+    sort_order,
+    created_at,
+    updated_at
+)
+
+SELECT
+    s.company_id,
+    s.id,
+    item.section_id,
+    item.subsection_id,
+    item.item_number,
+    item.description,
+    item.unit,
+    item.qty,
+    item.rate,
+    item.sort_order,
+    NOW(),
+    NOW()
+
+FROM lcl_structures s
+
+CROSS JOIN LATERAL (
+
+    VALUES
+
+    -- =====================================================
+    -- SECTION A MATERIALS
+    -- =====================================================
+
+    ('section_a', 'section_a_materials', '1', 'Ballast', 'Trucks', 7, 30000, 0),
+    ('section_a', 'section_a_materials', '2', 'Sand', 'Trucks', 8, 30000, 1),
+    ('section_a', 'section_a_materials', '3', 'Cement', 'Bags', 230, 850, 2),
+    ('section_a', 'section_a_materials', '4', 'Quarry Dust', 'Trucks', 20, 2180, 3),
+    ('section_a', 'section_a_materials', '5', 'Rock Sand', 'Trucks', 2, 30000, 4),
+    ('section_a', 'section_a_materials', '6', 'D20', 'Pcs', 5, 2700, 5),
+    ('section_a', 'section_a_materials', '7', 'D12', 'Pcs', 30, 1190, 6),
+    ('section_a', 'section_a_materials', '8', 'D10', 'Pcs', 62, 825, 7),
+    ('section_a', 'section_a_materials', '9', 'D8', 'Pcs', 80, 530, 8),
+
+    -- =====================================================
+    -- SECTION A LABOR
+    -- =====================================================
+
+    ('section_a', 'section_a_labor', '1', 'Setting Out', 'Item', 1, 6000, 0),
+    ('section_a', 'section_a_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1),
+    ('section_a', 'section_a_labor', '3', 'Excavation & Levelling', 'Item', 1, 40000, 2),
+    ('section_a', 'section_a_labor', '4', 'Bases & Trenches Concreting', 'Item', 1, 24000, 3),
+
+    -- =====================================================
+    -- SECTION B MATERIALS
+    -- =====================================================
+
+    ('section_b', 'section_b_materials', '1', 'Machine Cut Stones 6 by 9', 'Pcs', 2800, 60, 0),
+    ('section_b', 'section_b_materials', '2', 'Machine-cut 6x9', 'Pcs', 100, 60, 1),
+    ('section_b', 'section_b_materials', '3', 'Quarry Dust', 'Trucks', 1, 30000, 2),
+    ('section_b', 'section_b_materials', '4', 'Rock Sand', 'Trucks', 2, 30000, 3),
+    ('section_b', 'section_b_materials', '5', 'Sand', 'Trucks', 2, 30000, 4),
+
+    -- =====================================================
+    -- SECTION B LABOR
+    -- =====================================================
+
+    ('section_b', 'section_b_labor', '1', 'Setting & Levelling', 'Item', 1, 12000, 0),
+    ('section_b', 'section_b_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1),
+
+    -- =====================================================
+    -- SECTION C MATERIALS
+    -- =====================================================
+
+    ('section_c', 'section_c_materials', '1', 'Quarry Dust', 'Trucks', 1, 30000, 0),
+    ('section_c', 'section_c_materials', '2', 'Rock Sand', 'Trucks', 2, 30000, 1),
+    ('section_c', 'section_c_materials', '3', 'Timber 3x2', 'Ft', 2000, 25, 2),
+    ('section_c', 'section_c_materials', '4', 'Timber 6x1', 'Ft', 1500, 25, 3),
+
+    -- =====================================================
+    -- SECTION C LABOR
+    -- =====================================================
+
+    ('section_c', 'section_c_labor', '1', 'Formwork', 'Item', 1, 70000, 0),
+    ('section_c', 'section_c_labor', '2', 'Bar Bending', 'Item', 1, 60000, 1)
+
+) AS item(
+    section_id,
+    subsection_id,
+    item_number,
+    description,
+    unit,
+    qty,
+    rate,
+    sort_order
+)
+
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM lcl_template_items li
+    WHERE li.structure_id = s.id
+      AND li.section_id = item.section_id
+      AND li.subsection_id = item.subsection_id
+      AND li.item_number = item.item_number
 );

--- a/supabase/migrations/20250527_seed_lcl_default_boq.sql
+++ b/supabase/migrations/20250527_seed_lcl_default_boq.sql
@@ -1,211 +1,195 @@
--- =========================================================
--- SEED LCL DEFAULT BOQ STRUCTURE
--- =========================================================
+-- Seed LCL Default BOQ structure with data from BOQ-085 (PROPOSED RESIDENTIAL MAISONETTE)
+-- This migration creates a default LCL BOQ structure and populates it with all items from the PDF
 
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- Insert a special LCL BOQ structure (per company)
+-- Note: This assumes a function or trigger will auto-create this for each company, or we seed it once globally
+-- For now, we'll create a migration-friendly approach using a placeholder company_id
 
--- =========================================================
--- CREATE DEFAULT STRUCTURES PER COMPANY
--- =========================================================
-
+-- Structure definition with sections A-G
 INSERT INTO lcl_template_structures (
-    company_id,
-    name,
-    description,
-    structure_data,
-    is_active,
-    created_at,
-    updated_at
-)
-SELECT
-    c.id,
-    'LCL Default BOQ',
-    'Default BOQ structure for Layons Construction projects (BOQ-085: Proposed Residential Maisonette)',
-    
-    jsonb_build_object(
-        'sections',
-        jsonb_build_array(
-
-            jsonb_build_object(
-                'id', 'section_a',
-                'name', 'Section A: Foundation',
-                'subsections', jsonb_build_array(
-                    jsonb_build_object(
-                        'id', 'section_a_materials',
-                        'name', 'Materials'
-                    ),
-                    jsonb_build_object(
-                        'id', 'section_a_labor',
-                        'name', 'Labor'
-                    )
-                )
-            ),
-
-            jsonb_build_object(
-                'id', 'section_b',
-                'name', 'Section B: Ground Floor Walling',
-                'subsections', jsonb_build_array(
-                    jsonb_build_object(
-                        'id', 'section_b_materials',
-                        'name', 'Materials'
-                    ),
-                    jsonb_build_object(
-                        'id', 'section_b_labor',
-                        'name', 'Labor'
-                    )
-                )
-            ),
-
-            jsonb_build_object(
-                'id', 'section_c',
-                'name', 'Section C: Ground Floor Suspended Slab',
-                'subsections', jsonb_build_array(
-                    jsonb_build_object(
-                        'id', 'section_c_materials',
-                        'name', 'Materials'
-                    ),
-                    jsonb_build_object(
-                        'id', 'section_c_labor',
-                        'name', 'Labor'
-                    )
-                )
-            )
-
-        )
-    ),
-
-    true,
-    NOW(),
-    NOW()
-
-FROM companies c
-
+  company_id,
+  name,
+  description,
+  structure_data,
+  is_active,
+  created_at,
+  updated_at
+) 
+SELECT 
+  companies.id,
+  'LCL Default BOQ',
+  'Default BOQ structure for Layons Construction projects (BOQ-085: Proposed Residential Maisonette)',
+  jsonb_build_object(
+    'sections', jsonb_build_array(
+      jsonb_build_object('id', 'section_a', 'name', 'Section A: Foundation', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_a_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_a_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_b', 'name', 'Section B: Ground Floor Walling', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_b_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_b_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_c', 'name', 'Section C: Ground Floor Suspended Slab', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_c_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_c_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_d', 'name', 'Section D: First Floor Walling and Columns', 'parent_section_id', 'section_b', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_d_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_d_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_e', 'name', 'Section E: First Floor Suspended Slab', 'parent_section_id', 'section_c', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_e_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_e_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_f', 'name', 'Section F: Second Floor Walling and Columns', 'parent_section_id', 'section_b', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_f_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_f_labor', 'name', 'Labor')
+      )),
+      jsonb_build_object('id', 'section_g', 'name', 'Section G: Second Floor Suspended Slab', 'parent_section_id', 'section_c', 'subsections', jsonb_build_array(
+        jsonb_build_object('id', 'section_g_materials', 'name', 'Materials'),
+        jsonb_build_object('id', 'section_g_labor', 'name', 'Labor')
+      ))
+    )
+  ),
+  true,
+  NOW(),
+  NOW()
+FROM companies
 WHERE NOT EXISTS (
-    SELECT 1
-    FROM lcl_template_structures lts
-    WHERE lts.company_id = c.id
-      AND lts.name = 'LCL Default BOQ'
-);
+  SELECT 1 FROM lcl_template_structures 
+  WHERE name = 'LCL Default BOQ' AND company_id = companies.id
+)
+ON CONFLICT DO NOTHING;
 
--- =========================================================
--- INSERT TEMPLATE ITEMS
--- =========================================================
-
+-- Helper: Get the default LCL structure IDs by company
 WITH lcl_structures AS (
-    SELECT
-        id,
-        company_id
-    FROM lcl_template_structures
-    WHERE name = 'LCL Default BOQ'
+  SELECT id, company_id FROM lcl_template_structures 
+  WHERE name = 'LCL Default BOQ'
 )
-
 INSERT INTO lcl_template_items (
-    company_id,
-    structure_id,
-    section_id,
-    subsection_id,
-    item_number,
-    description,
-    unit,
-    default_qty,
-    default_rate,
-    sort_order,
-    created_at,
-    updated_at
+  company_id,
+  structure_id,
+  section_id,
+  subsection_id,
+  item_number,
+  description,
+  unit,
+  default_qty,
+  default_rate,
+  sort_order,
+  created_at,
+  updated_at
 )
-
-SELECT
-    s.company_id,
-    s.id,
-    item.section_id,
-    item.subsection_id,
-    item.item_number,
-    item.description,
-    item.unit,
-    item.qty,
-    item.rate,
-    item.sort_order,
-    NOW(),
-    NOW()
-
-FROM lcl_structures s
-
-CROSS JOIN LATERAL (
-
-    VALUES
-
-    -- =====================================================
-    -- SECTION A MATERIALS
-    -- =====================================================
-
-    ('section_a', 'section_a_materials', '1', 'Ballast', 'Trucks', 7, 30000, 0),
-    ('section_a', 'section_a_materials', '2', 'Sand', 'Trucks', 8, 30000, 1),
-    ('section_a', 'section_a_materials', '3', 'Cement', 'Bags', 230, 850, 2),
-    ('section_a', 'section_a_materials', '4', 'Quarry Dust', 'Trucks', 20, 2180, 3),
-    ('section_a', 'section_a_materials', '5', 'Rock Sand', 'Trucks', 2, 30000, 4),
-    ('section_a', 'section_a_materials', '6', 'D20', 'Pcs', 5, 2700, 5),
-    ('section_a', 'section_a_materials', '7', 'D12', 'Pcs', 30, 1190, 6),
-    ('section_a', 'section_a_materials', '8', 'D10', 'Pcs', 62, 825, 7),
-    ('section_a', 'section_a_materials', '9', 'D8', 'Pcs', 80, 530, 8),
-
-    -- =====================================================
-    -- SECTION A LABOR
-    -- =====================================================
-
-    ('section_a', 'section_a_labor', '1', 'Setting Out', 'Item', 1, 6000, 0),
-    ('section_a', 'section_a_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1),
-    ('section_a', 'section_a_labor', '3', 'Excavation & Levelling', 'Item', 1, 40000, 2),
-    ('section_a', 'section_a_labor', '4', 'Bases & Trenches Concreting', 'Item', 1, 24000, 3),
-
-    -- =====================================================
-    -- SECTION B MATERIALS
-    -- =====================================================
-
-    ('section_b', 'section_b_materials', '1', 'Machine Cut Stones 6 by 9', 'Pcs', 2800, 60, 0),
-    ('section_b', 'section_b_materials', '2', 'Machine-cut 6x9', 'Pcs', 100, 60, 1),
-    ('section_b', 'section_b_materials', '3', 'Quarry Dust', 'Trucks', 1, 30000, 2),
-    ('section_b', 'section_b_materials', '4', 'Rock Sand', 'Trucks', 2, 30000, 3),
-    ('section_b', 'section_b_materials', '5', 'Sand', 'Trucks', 2, 30000, 4),
-
-    -- =====================================================
-    -- SECTION B LABOR
-    -- =====================================================
-
-    ('section_b', 'section_b_labor', '1', 'Setting & Levelling', 'Item', 1, 12000, 0),
-    ('section_b', 'section_b_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1),
-
-    -- =====================================================
-    -- SECTION C MATERIALS
-    -- =====================================================
-
-    ('section_c', 'section_c_materials', '1', 'Quarry Dust', 'Trucks', 1, 30000, 0),
-    ('section_c', 'section_c_materials', '2', 'Rock Sand', 'Trucks', 2, 30000, 1),
-    ('section_c', 'section_c_materials', '3', 'Timber 3x2', 'Ft', 2000, 25, 2),
-    ('section_c', 'section_c_materials', '4', 'Timber 6x1', 'Ft', 1500, 25, 3),
-
-    -- =====================================================
-    -- SECTION C LABOR
-    -- =====================================================
-
-    ('section_c', 'section_c_labor', '1', 'Formwork', 'Item', 1, 70000, 0),
-    ('section_c', 'section_c_labor', '2', 'Bar Bending', 'Item', 1, 60000, 1)
-
-) AS item(
-    section_id,
-    subsection_id,
-    item_number,
-    description,
-    unit,
-    qty,
-    rate,
-    sort_order
-)
-
+SELECT 
+  s.company_id,
+  s.id,
+  item.section_id,
+  item.subsection_id,
+  item.item_number,
+  item.description,
+  item.unit,
+  item.qty,
+  item.rate,
+  item.sort_order,
+  NOW(),
+  NOW()
+FROM lcl_structures s,
+LATERAL (
+  -- SECTION A: FOUNDATION - MATERIALS
+  SELECT 'section_a', 'section_a_materials', '1', 'Ballast', 'Trucks', 7, 30000, 0 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '2', 'Sand', 'Trucks', 8, 30000, 1 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '3', 'Cement', 'Bags', 230, 850, 2 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '4', 'Quarry dust', 'Trucks', 20, 2180, 3 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '5', 'Rock sand', 'Trucks', 2, 30000, 4 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '6', 'D20', 'Pcs', 5, 2700, 5 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '7', 'D12', 'Pcs', 30, 1190, 6 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '8', 'D10', 'Pcs', 62, 825, 7 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '9', 'D8', 'Pcs', 80, 530, 8 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '10', 'Binding Wire', 'Rolls', 3, 2700, 9 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '11', 'Hacksaw Blades', 'Pcs', 10, 100, 10 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '12', 'Nails 3"', 'Kgs', 20, 180, 11 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '13', 'Nails 4"', 'Kgs', 20, 180, 12 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '14', 'Foundation Stones', 'Ft', 2800, 60, 13 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '15', 'Hoop Iron', 'Pcs', 8, 1500, 14 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '16', 'Hardcore/Murram', 'Trucks', 14, 6000, 15 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '17', 'D.p.m', 'Rolls', 8, 1500, 16 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '18', 'B.r.c A98', 'Rolls', 3, 19000, 17 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '19', 'Plumbing Items', 'Item', 1, 10000, 18 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '20', 'Termite Treatment', 'Ltrs', 2, 1200, 19 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '21', 'Timber 6 by 1', 'Ft', 800, 25, 20 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '22', 'Profiles', 'Pcs', 40, 200, 21 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '23', 'White Wash 25kg', 'Bags', 2, 250, 22 UNION ALL
+  SELECT 'section_a', 'section_a_materials', '24', 'Setting Out Lines', 'Pcs', 10, 60, 23 UNION ALL
+  
+  -- SECTION A: FOUNDATION - LABOR
+  SELECT 'section_a', 'section_a_labor', '1', 'Setting Out', 'Item', 1, 6000, 0 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '3', 'Excavation & Levelling', 'Item', 1, 40000, 2 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '4', 'Bases & Trenches Concreting', 'Item', 1, 24000, 3 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '5', 'Masonry Works', 'Item', 1, 120000, 4 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '6', 'Formwork', 'Item', 1, 8000, 5 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '7', 'Column Concreting', 'Item', 1, 14000, 6 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '8', 'Backfilling & Compaction', 'Item', 1, 22000, 7 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '9', 'Laying Of D.p.m, Termite Treatment & Laying of B.r.c', 'Item', 1, 6000, 8 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '10', 'Plumbing Works', 'Item', 1, 8000, 9 UNION ALL
+  SELECT 'section_a', 'section_a_labor', '11', 'Foundation Slab Concreting', 'Item', 1, 28000, 10 UNION ALL
+  
+  -- SECTION B: GROUND FLOOR WALLING - MATERIALS
+  SELECT 'section_b', 'section_b_materials', '1', 'Machine Cut Stones 6 by 9', 'Pcs', 2800, 60, 0 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '2', 'Machine-cut 6x9', 'Pcs', 100, 60, 1 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '3', 'Quarry dust', 'Trucks', 1, 30000, 2 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '4', 'Rock sand', 'Trucks', 2, 30000, 3 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '5', 'Sand', 'Trucks', 2, 30000, 4 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '6', 'Cement', 'Bags', 90, 850, 5 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '7', 'D20', 'Pcs', 5, 2700, 6 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '8', 'D16', 'Pcs', 27, 2180, 7 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '9', 'D12', 'Pcs', 15, 1190, 8 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '10', 'D10', 'Pcs', 20, 825, 9 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '11', 'D8', 'Pcs', 20, 530, 10 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '12', 'Binding Wire', 'Rolls', 1, 2700, 11 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '13', 'Hacksaw Blades', 'Pcs', 10, 100, 12 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '14', 'Timber 6x1', 'Ft', 1000, 25, 13 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '15', 'Nails 3"', 'Kgs', 5, 180, 14 UNION ALL
+  SELECT 'section_b', 'section_b_materials', '16', 'Nails 4"', 'Kgs', 5, 180, 15 UNION ALL
+  
+  -- SECTION B: GROUND FLOOR WALLING - LABOR
+  SELECT 'section_b', 'section_b_labor', '1', 'Setting & Levelling', 'Item', 1, 12000, 0 UNION ALL
+  SELECT 'section_b', 'section_b_labor', '2', 'Bar Bending', 'Item', 1, 14000, 1 UNION ALL
+  SELECT 'section_b', 'section_b_labor', '3', 'Masonry works', 'Item', 1, 140000, 2 UNION ALL
+  SELECT 'section_b', 'section_b_labor', '4', 'Column Formwork', 'Item', 1, 12000, 3 UNION ALL
+  SELECT 'section_b', 'section_b_labor', '5', 'Column Concreting', 'Item', 1, 16000, 4 UNION ALL
+  
+  -- SECTION C: GROUND FLOOR SUSPENDED SLAB - MATERIALS
+  SELECT 'section_c', 'section_c_materials', '1', 'Quarry dust', 'Trucks', 1, 30000, 0 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '2', 'Rock sand', 'Trucks', 2, 30000, 1 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '3', 'Timber 3x2', 'Ft', 2000, 25, 2 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '4', 'Timber 6x1', 'Ft', 1500, 25, 3 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '5', 'Profiles', 'Pcs', 250, 180, 4 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '6', 'Trappers', 'Pcs', 180, 120, 5 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '7', 'Nails 4"', 'Bags', 1, 8000, 6 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '8', 'Nails 3"', 'Bags', 1, 8000, 7 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '9', 'D16', 'Pcs', 12, 2180, 8 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '10', 'D12', 'Pcs', 70, 1190, 9 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '11', 'D10', 'Pcs', 320, 825, 10 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '12', 'D8', 'Pcs', 90, 530, 11 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '13', 'Binding Wire', 'Rolls', 5, 2700, 12 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '14', 'Blades', 'Pcs', 20, 100, 13 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '15', 'Cutting disks', 'Pcs', 10, 150, 14 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '16', 'D.P.M', 'Rolls', 8, 1500, 15 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '17', 'Ballast', 'Trucks', 6, 30000, 16 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '18', 'Cement', 'Bags', 180, 850, 17 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '19', 'Electrical Items', 'Item', 1, 15000, 18 UNION ALL
+  SELECT 'section_c', 'section_c_materials', '20', 'Plumbing Items', 'Item', 1, 10000, 19 UNION ALL
+  
+  -- SECTION C: GROUND FLOOR SUSPENDED SLAB - LABOR
+  SELECT 'section_c', 'section_c_labor', '1', 'Formwork', 'Item', 1, 70000, 0 UNION ALL
+  SELECT 'section_c', 'section_c_labor', '2', 'Bar Bending', 'Item', 1, 60000, 1 UNION ALL
+  SELECT 'section_c', 'section_c_labor', '3', 'Electrical Works', 'Item', 1, 18000, 2 UNION ALL
+  SELECT 'section_c', 'section_c_labor', '4', 'Plumbing Works', 'Item', 1, 10000, 3 UNION ALL
+  SELECT 'section_c', 'section_c_labor', '5', 'Concreting', 'Item', 1, 40000, 4 UNION ALL
+  
+) AS item(section_id, subsection_id, item_number, description, unit, qty, rate, sort_order)
 WHERE NOT EXISTS (
-    SELECT 1
-    FROM lcl_template_items li
-    WHERE li.structure_id = s.id
-      AND li.section_id = item.section_id
-      AND li.subsection_id = item.subsection_id
-      AND li.item_number = item.item_number
+  SELECT 1 FROM lcl_template_items 
+  WHERE structure_id = s.id AND section_id = item.section_id AND subsection_id = item.subsection_id AND item_number = item.item_number
 );

--- a/supabase/migrations/20250528_add_section_h_roofing.sql
+++ b/supabase/migrations/20250528_add_section_h_roofing.sql
@@ -1,0 +1,84 @@
+-- Add Section H: Roofing to LCL Default BOQ structure
+-- This migration adds Section H (Roofing) with Materials and Labor subsections to the existing BOQ template
+
+-- Helper: Get the default LCL structure IDs by company
+WITH lcl_structures AS (
+  SELECT id, company_id FROM lcl_template_structures 
+  WHERE name = 'LCL Default BOQ'
+),
+update_structures AS (
+  -- Update existing structures to append Section H
+  UPDATE lcl_template_structures
+  SET structure_data = jsonb_set(
+    structure_data,
+    '{sections}',
+    structure_data->'sections' || jsonb_build_array(
+      jsonb_build_object(
+        'id', 'section_h',
+        'name', 'Section H: Roofing',
+        'subsections', jsonb_build_array(
+          jsonb_build_object('id', 'section_h_materials', 'name', 'Materials'),
+          jsonb_build_object('id', 'section_h_labor', 'name', 'Labor')
+        )
+      )
+    )
+  ),
+  updated_at = NOW()
+  WHERE name = 'LCL Default BOQ'
+  RETURNING id, company_id
+)
+-- Insert Section H items
+INSERT INTO lcl_template_items (
+  company_id,
+  structure_id,
+  section_id,
+  subsection_id,
+  item_number,
+  description,
+  unit,
+  default_qty,
+  default_rate,
+  sort_order,
+  created_at,
+  updated_at
+)
+SELECT 
+  us.company_id,
+  us.id,
+  item.section_id,
+  item.subsection_id,
+  item.item_number,
+  item.description,
+  item.unit,
+  item.qty,
+  item.rate,
+  item.sort_order,
+  NOW(),
+  NOW()
+FROM update_structures us,
+LATERAL (
+  -- SECTION H: ROOFING - MATERIALS
+  SELECT 'section_h', 'section_h_materials', '1', 'Timber 4 by 2', 'Ft', 4800, 35.00, 0 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '2', 'Timber 3 by 2', 'Ft', 3900, 27.00, 1 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '3', 'Timber 2 by 2', 'Ft', 2000, 18.00, 2 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '4', 'Fascia 10 by 1', 'Ft', 300, 110.00, 3 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '5', 'Nails 4"', 'Kgs', 100, 180.00, 4 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '6', 'Nails 3"', 'Kgs', 50, 180.00, 5 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '7', 'Nails 2"', 'Kgs', 10, 180.00, 6 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '8', 'Nails 5"', 'Kgs', 20, 180.00, 7 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '9', 'Roofing Nails', 'Kgs', 50, 250.00, 8 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '10', 'Mabati Vitalile', 'Linear Metres', 650, 750.00, 9 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '11', 'Ridge caps', 'Pcs', 45, 700.00, 10 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '12', 'Valley Trays', 'Pcs', 15, 700.00, 11 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '13', 'Rubber Washers', 'Pkts', 50, 150.00, 12 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '14', 'Paint', 'Gal', 2, 1300.00, 13 UNION ALL
+  SELECT 'section_h', 'section_h_materials', '15', 'Brushes', 'Gal', 1, 300.00, 14 UNION ALL
+  
+  -- SECTION H: ROOFING - LABOR
+  SELECT 'section_h', 'section_h_labor', '1', 'Roofing & Blundering Ceiling Joists', 'Item', 1, 250000.00, 0
+) AS item(section_id, subsection_id, item_number, description, unit, qty, rate, sort_order)
+WHERE NOT EXISTS (
+  SELECT 1 FROM lcl_template_items 
+  WHERE structure_id = us.id AND section_id = item.section_id AND subsection_id = item.subsection_id AND item_number = item.item_number
+)
+ON CONFLICT DO NOTHING;

--- a/supabase/migrations/20250528_add_section_h_roofing.sql
+++ b/supabase/migrations/20250528_add_section_h_roofing.sql
@@ -3,11 +3,12 @@
 
 -- Helper: Get the default LCL structure IDs by company
 WITH lcl_structures AS (
-  SELECT id, company_id FROM lcl_template_structures 
+  SELECT id, company_id FROM lcl_template_structures
   WHERE name = 'LCL Default BOQ'
+    AND NOT (structure_data->'sections' @> jsonb_build_array(jsonb_build_object('id', 'section_h')))
 ),
 update_structures AS (
-  -- Update existing structures to append Section H
+  -- Update existing structures to append Section H (only if it doesn't already exist)
   UPDATE lcl_template_structures
   SET structure_data = jsonb_set(
     structure_data,
@@ -24,7 +25,7 @@ update_structures AS (
     )
   ),
   updated_at = NOW()
-  WHERE name = 'LCL Default BOQ'
+  WHERE id IN (SELECT id FROM lcl_structures)
   RETURNING id, company_id
 )
 -- Insert Section H items

--- a/supabase/migrations/20250528_remove_d16_with_space.sql
+++ b/supabase/migrations/20250528_remove_d16_with_space.sql
@@ -1,0 +1,10 @@
+-- Remove "D 16" (with space) from Section B Materials
+-- Keep "D16" (without space)
+
+DELETE FROM lcl_template_items
+WHERE section_id = 'section_b'
+  AND subsection_id = 'section_b_materials'
+  AND description = 'D 16'
+  AND unit = 'Pcs'
+  AND default_qty = 27
+  AND default_rate = 2180;


### PR DESCRIPTION
### Summary
This PR updates the LCL BOQ default template with Section H (Roofing), corrects a stone size label, removes a duplicate item, and adds the BOQ ID display in the edit modal header.

### Problem
The LCL BOQ default template was missing Section H (Roofing), had an incorrect stone size label ("9 by 9" instead of "6 by 9"), and contained a duplicate "D 16" (with space) entry in Section B materials. Additionally, users had no visible reference to which BOQ ID they were editing in the modal.

### Solution
- Added a new migration to append Section H (Roofing) with materials and labor subsections to the LCL Default BOQ template.
- Corrected the stone size label in the seed migration and removed the "D 16" (with space) duplicate via a targeted delete migration.
- Displayed the BOQ ID in the `EditLCLBOQModal` header for user reference.
- Added deduplication logic in `lclTemplateService` to prevent duplicate section key errors at runtime.

### Key Changes
- **`EditLCLBOQModal.tsx`**: Added a conditionally rendered `<p>` element in the `DialogHeader` showing `"editng LCL id {boq.id}"` when `boq.id` is present, styled with `text-sm text-muted-foreground`.
- **`lclTemplateService.ts`**: Added deduplication of sections using a `Set` before building the hierarchical view, preventing duplicate key errors.
- **`20250527_seed_lcl_default_boq.sql`**: Updated Section B item label from `"Machine Cut Stones 9 by 9"` to `"Machine Cut Stones 6 by 9"`.
- **`20250528_add_section_h_roofing.sql`**: New migration that appends Section H (Roofing) to the LCL Default BOQ structure and inserts 15 material items and 1 labor item, with idempotency guards.
- **`20250528_remove_d16_with_space.sql`**: New migration that deletes the `"D 16"` (with space) entry from Section B materials, retaining the `"D16"` (no space) entry.


---

<a href="https://builder.io/app/projects/9c2ac07e8a7a42a081dd/oval-fountain-hnmazgk6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://9c2ac07e8a7a42a081dd-oval-fountain-hnmazgk6_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=9c2ac07e8a7a42a081dd&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 272`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9c2ac07e8a7a42a081dd</projectId>-->
<!--<branchName>oval-fountain-hnmazgk6</branchName>-->