### PR TITLE
Auto-renumber LCL BOQ items after deletion

### DIFF
--- a/migrations/20250528_renumber_section_b_materials.sql
+++ b/migrations/20250528_renumber_section_b_materials.sql
@@ -1,0 +1,27 @@
+-- Migration: Renumber Section B Materials items to start from 1
+-- Purpose: After removing an item from Section B > Materials, renumber all remaining items
+-- from 1 instead of starting at 2
+--
+-- Current state: Items numbered 2, 3, 4, 5, 6, 7, ...
+-- Desired state: Items numbered 1, 2, 3, 4, 5, 6, ...
+--
+-- This migration uses a window function to renumber items sequentially while maintaining
+-- the existing sort order
+
+WITH ranked_items AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (ORDER BY sort_order) - 1 as new_sort_order,
+    ROW_NUMBER() OVER (ORDER BY sort_order)::TEXT as new_item_number
+  FROM lcl_template_items
+  WHERE section_id = 'SECTION_B'
+    AND subsection_id = 'MATERIALS'
+  ORDER BY sort_order
+)
+UPDATE lcl_template_items
+SET
+  item_number = ranked_items.new_item_number,
+  sort_order = ranked_items.new_sort_order,
+  updated_at = NOW()
+FROM ranked_items
+WHERE lcl_template_items.id = ranked_items.id;

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -121,12 +121,54 @@ export class LCLTemplateService {
   }
 
   async deleteItem(itemId: string): Promise<void> {
-    const { error } = await supabase
+    // Get the item to be deleted to find its section and subsection
+    const { data: itemToDelete, error: fetchError } = await supabase
+      .from('lcl_template_items')
+      .select('section_id, subsection_id')
+      .eq('id', itemId)
+      .single();
+
+    if (fetchError) throw new Error(`Failed to fetch item: ${fetchError.message}`);
+    if (!itemToDelete) throw new Error('Item not found');
+
+    // Delete the item
+    const { error: deleteError } = await supabase
       .from('lcl_template_items')
       .delete()
       .eq('id', itemId);
 
-    if (error) throw new Error(`Failed to delete item: ${error.message}`);
+    if (deleteError) throw new Error(`Failed to delete item: ${deleteError.message}`);
+
+    // Get all remaining items in the same section and subsection, ordered by sort_order
+    const { data: remainingItems, error: fetchRemainingError } = await supabase
+      .from('lcl_template_items')
+      .select('id')
+      .eq('section_id', itemToDelete.section_id)
+      .eq('subsection_id', itemToDelete.subsection_id)
+      .order('sort_order', { ascending: true });
+
+    if (fetchRemainingError) throw new Error(`Failed to fetch remaining items: ${fetchRemainingError.message}`);
+
+    // Renumber the remaining items sequentially
+    if (remainingItems && remainingItems.length > 0) {
+      const updates = remainingItems.map((item, index) => ({
+        id: item.id,
+        item_number: (index + 1).toString(),
+        sort_order: index,
+      }));
+
+      for (const update of updates) {
+        const { error: updateError } = await supabase
+          .from('lcl_template_items')
+          .update({
+            item_number: update.item_number,
+            sort_order: update.sort_order,
+          })
+          .eq('id', update.id);
+
+        if (updateError) throw new Error(`Failed to renumber items: ${updateError.message}`);
+      }
+    }
   }
 
   async getHierarchicalData(


### PR DESCRIPTION
### Summary
This PR fixes item numbering in the LCL BOQ template so that when an item is deleted from a section, the remaining items are automatically renumbered sequentially starting from 1.

### Problem
After removing an item from Section B (Materials) of the LCL BOQ, the numbering of remaining items started from 2 instead of 1, leaving a gap in the sequence.

### Solution
The `deleteItem` method in `LCLTemplateService` was updated to fetch the deleted item's section context, then renumber all remaining items in that section/subsection sequentially after deletion. A one-time SQL migration was also added to fix the existing out-of-sequence numbering in the database.

### Key Changes
- **`src/services/lclTemplateService.ts`**: Enhanced `deleteItem` to automatically renumber remaining items in the same section and subsection after a deletion, updating both `item_number` and `sort_order` fields sequentially.
- **`migrations/20250528_renumber_section_b_materials.sql`**: Added a one-time migration using a SQL window function (`ROW_NUMBER()`) to renumber existing Section B > Materials items from 1 instead of 2, correcting the current state in the database.


---

<a href="https://builder.io/app/projects/dc1a9a50827f4d068f43/chiffon-soul-wc80nrjf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://dc1a9a50827f4d068f43-chiffon-soul-wc80nrjf_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=dc1a9a50827f4d068f43&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 273`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dc1a9a50827f4d068f43</projectId>-->
<!--<branchName>chiffon-soul-wc80nrjf</branchName>-->