### PR TITLE
Disable view/download for LCL BOQs and add DB renumber trigger

### DIFF
--- a/migrations/20250528_create_lcl_items_renumber_trigger.sql
+++ b/migrations/20250528_create_lcl_items_renumber_trigger.sql
@@ -1,0 +1,41 @@
+-- Migration: Create trigger for automatic LCL template item renumbering
+-- Purpose: When an item is deleted from lcl_template_items, automatically renumber
+--          all remaining items in the same section_id and subsection_id
+--
+-- Rationale: Instead of handling renumbering in the application layer (JavaScript),
+--          use a PostgreSQL trigger to ensure consistency and atomicity.
+--          The database guarantees renumbering happens immediately with the delete.
+
+-- Create the trigger function
+CREATE OR REPLACE FUNCTION renumber_lcl_template_items_on_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Renumber items in the same section and subsection after deletion
+  WITH reordered AS (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (ORDER BY sort_order) AS new_item_number,
+      ROW_NUMBER() OVER (ORDER BY sort_order) - 1 AS new_sort_order
+    FROM lcl_template_items
+    WHERE section_id = OLD.section_id
+      AND subsection_id = OLD.subsection_id
+  )
+  UPDATE lcl_template_items
+  SET
+    item_number = reordered.new_item_number::text,
+    sort_order = reordered.new_sort_order,
+    updated_at = NOW()
+  FROM reordered
+  WHERE lcl_template_items.id = reordered.id;
+  
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger that fires AFTER DELETE
+DROP TRIGGER IF EXISTS lcl_template_items_renumber_on_delete ON lcl_template_items;
+
+CREATE TRIGGER lcl_template_items_renumber_on_delete
+AFTER DELETE ON lcl_template_items
+FOR EACH ROW
+EXECUTE FUNCTION renumber_lcl_template_items_on_delete();

--- a/migrations/20250528_create_lcl_items_renumber_trigger.sql
+++ b/migrations/20250528_create_lcl_items_renumber_trigger.sql
@@ -14,20 +14,24 @@ BEGIN
   WITH reordered AS (
     SELECT
       id,
-      ROW_NUMBER() OVER (ORDER BY sort_order) AS new_item_number,
-      ROW_NUMBER() OVER (ORDER BY sort_order) - 1 AS new_sort_order
+      ROW_NUMBER() OVER (
+        ORDER BY sort_order, created_at, id
+      ) AS new_item_number,
+      ROW_NUMBER() OVER (
+        ORDER BY sort_order, created_at, id
+      ) - 1 AS new_sort_order
     FROM lcl_template_items
     WHERE section_id = OLD.section_id
       AND subsection_id = OLD.subsection_id
   )
-  UPDATE lcl_template_items
+  UPDATE lcl_template_items li
   SET
     item_number = reordered.new_item_number::text,
     sort_order = reordered.new_sort_order,
     updated_at = NOW()
   FROM reordered
-  WHERE lcl_template_items.id = reordered.id;
-  
+  WHERE li.id = reordered.id;
+
   RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;

--- a/src/pages/BOQs.tsx
+++ b/src/pages/BOQs.tsx
@@ -732,7 +732,14 @@ export default function BOQs() {
                         <TableCell className="text-right text-xs md:text-sm">{new Intl.NumberFormat('en-KE', { style: 'currency', currency: b.currency || 'KES' }).format(Number(b.total_amount || b.subtotal || 0))}</TableCell>
                         <TableCell>
                           <div className="flex items-center gap-1 md:gap-2 flex-wrap">
-                            <Button size="icon" variant="ghost" onClick={() => setViewing(b)} title="View" className="h-8 w-8 md:h-9 md:w-9">
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => !linkedBOQIds.has(b.id) && setViewing(b)}
+                              title={linkedBOQIds.has(b.id) ? "View unavailable: Linked to LCL template" : "View"}
+                              disabled={linkedBOQIds.has(b.id)}
+                              className="h-8 w-8 md:h-9 md:w-9"
+                            >
                               <Eye className="h-3 w-3 md:h-4 md:w-4" />
                             </Button>
                             <Button
@@ -745,7 +752,14 @@ export default function BOQs() {
                             >
                               <Pencil className="h-3 w-3 md:h-4 md:w-4" />
                             </Button>
-                            <Button size="icon" variant="ghost" onClick={() => handleDownloadPDF(b)} title="Download PDF" className="h-8 w-8 md:h-9 md:w-9">
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => !linkedBOQIds.has(b.id) && handleDownloadPDF(b)}
+                              title={linkedBOQIds.has(b.id) ? "Download unavailable: Linked to LCL template" : "Download PDF"}
+                              disabled={linkedBOQIds.has(b.id)}
+                              className="h-8 w-8 md:h-9 md:w-9"
+                            >
                               <Download className="h-3 w-3 md:h-4 md:w-4" />
                             </Button>
                             {b.number === 'BOQ-20251124-1441' && (

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -121,54 +121,12 @@ export class LCLTemplateService {
   }
 
   async deleteItem(itemId: string): Promise<void> {
-    // Get the item to be deleted to find its section and subsection
-    const { data: itemToDelete, error: fetchError } = await supabase
-      .from('lcl_template_items')
-      .select('section_id, subsection_id')
-      .eq('id', itemId)
-      .single();
-
-    if (fetchError) throw new Error(`Failed to fetch item: ${fetchError.message}`);
-    if (!itemToDelete) throw new Error('Item not found');
-
-    // Delete the item
-    const { error: deleteError } = await supabase
+    const { error } = await supabase
       .from('lcl_template_items')
       .delete()
       .eq('id', itemId);
 
-    if (deleteError) throw new Error(`Failed to delete item: ${deleteError.message}`);
-
-    // Get all remaining items in the same section and subsection, ordered by sort_order
-    const { data: remainingItems, error: fetchRemainingError } = await supabase
-      .from('lcl_template_items')
-      .select('id')
-      .eq('section_id', itemToDelete.section_id)
-      .eq('subsection_id', itemToDelete.subsection_id)
-      .order('sort_order', { ascending: true });
-
-    if (fetchRemainingError) throw new Error(`Failed to fetch remaining items: ${fetchRemainingError.message}`);
-
-    // Renumber the remaining items sequentially
-    if (remainingItems && remainingItems.length > 0) {
-      const updates = remainingItems.map((item, index) => ({
-        id: item.id,
-        item_number: (index + 1).toString(),
-        sort_order: index,
-      }));
-
-      for (const update of updates) {
-        const { error: updateError } = await supabase
-          .from('lcl_template_items')
-          .update({
-            item_number: update.item_number,
-            sort_order: update.sort_order,
-          })
-          .eq('id', update.id);
-
-        if (updateError) throw new Error(`Failed to renumber items: ${updateError.message}`);
-      }
-    }
+    if (error) throw new Error(`Failed to delete item: ${error.message}`);
   }
 
   async getHierarchicalData(


### PR DESCRIPTION
### Summary
This PR disables the view and download action buttons for BOQs linked to an LCL template, and replaces application-layer item renumbering logic with a PostgreSQL trigger that automatically renumbers items after deletion.

### Problem
1. BOQs linked to LCL templates were still showing active view and download icons, which could lead to confusing or unsupported actions.
2. When an item was deleted from an LCL BOQ, the remaining items were renumbered via multiple sequential application-layer database calls — an approach that was fragile and non-atomic.

### Solution
- The view and download buttons in the BOQs table are now disabled (with descriptive tooltips) when the BOQ is linked to an LCL template, using the existing `linkedBOQIds` set.
- A PostgreSQL `AFTER DELETE` trigger (`lcl_template_items_renumber_on_delete`) was introduced to handle renumbering atomically at the database level, replacing the multi-step JavaScript logic.

### Key Changes
- **`src/pages/BOQs.tsx`**: View (`Eye`) and Download buttons are disabled and show an explanatory tooltip when `linkedBOQIds.has(b.id)` is true. Click handlers also guard against action when linked.
- **`src/services/lclTemplateService.ts`**: Removed the fetch-then-delete-then-renumber logic from `deleteItem()`. The method now performs a single delete call and relies on the DB trigger for renumbering.
- **`migrations/20250528_create_lcl_items_renumber_trigger.sql`**: New migration that creates the `renumber_lcl_template_items_on_delete` trigger function and attaches it to `lcl_template_items`. It uses `ROW_NUMBER() OVER (ORDER BY sort_order, created_at, id)` to reassign sequential `item_number` and `sort_order` values for all remaining items in the same `section_id` and `subsection_id`.


---

<a href="https://builder.io/app/projects/3f19ffa6daa5419c8b2c/strong-crack-sjjnut0i"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://3f19ffa6daa5419c8b2c-strong-crack-sjjnut0i_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=3f19ffa6daa5419c8b2c&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 274`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3f19ffa6daa5419c8b2c</projectId>-->
<!--<branchName>strong-crack-sjjnut0i</branchName>-->