### PR TITLE
Fix LCL BOQ PDF table headers per subsection

### DIFF
--- a/src/utils/boqPdfGenerator.ts
+++ b/src/utils/boqPdfGenerator.ts
@@ -49,6 +49,7 @@ export interface BoqPdfOptions {
   invoiceNumber?: string;
   invoiceDate?: string;
   useCurrentDate?: boolean;
+  isLCLBOQ?: boolean;
 }
 
 export async function downloadBOQPDF(doc: BoqDocument, company?: { name: string; logo_url?: string; address?: string; city?: string; country?: string; phone?: string; email?: string }, options?: BoqPdfOptions) {
@@ -239,6 +240,7 @@ export async function downloadBOQPDF(doc: BoqDocument, company?: { name: string;
     showCalculatedValuesInTerms: doc.showCalculatedValuesInTerms,
     currency: currency,
     customTitle: options?.customTitle,
-    stampImageUrl: options?.stampImageUrl
+    stampImageUrl: options?.stampImageUrl,
+    isLCLBOQ: options?.isLCLBOQ
   });
 }

--- a/src/utils/lclBoqPdfGenerator.ts
+++ b/src/utils/lclBoqPdfGenerator.ts
@@ -216,5 +216,6 @@ export async function downloadLCLBOQPDF(
     currency: currency,
     customTitle: options?.customTitle,
     stampImageUrl: options?.stampImageUrl,
+    isLCLBOQ: true,
   });
 }

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -414,6 +414,7 @@ export interface DocumentData {
   customTitle?: string; // Optional custom title for BOQ PDFs
   stampImageUrl?: string; // Optional stamp image URL for special PDFs
   display_as_percentage?: boolean; // Whether to display calculated values instead of percentages in PDF
+  isLCLBOQ?: boolean; // Whether this is an LCL BOQ (applies table-splitting for each subsection)
   customer: {
     name: string;
     email?: string;
@@ -3272,6 +3273,66 @@ export const generatePDF = async (data: DocumentData) => {
         <!-- Items Section -->
         ${data.items && data.items.length > 0 ? `
         <div class="items-section">
+          ${data.isLCLBOQ && data.type === 'boq' ? (() => {
+            let tableHtml = '';
+            let currentTable: string[] = [];
+            let isFirstTable = true;
+            let itemIndex = 0;
+
+            const closeTable = () => {
+              if (currentTable.length > 0) {
+                tableHtml += `<table class="items-table" style="${!isFirstTable ? 'margin-top: 20px;' : ''}">
+                  <thead>
+                    <tr>
+                      <th style="width: 5%;">#</th>
+                      <th style="width: 45%;">Item Description</th>
+                      <th style="width: 10%;">Qty</th>
+                      <th style="width: 10%;">Unit</th>
+                      <th style="width: 15%;">Rate</th>
+                      <th style="width: 15%;">Amount</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${currentTable.join('')}
+                  </tbody>
+                </table>`;
+                currentTable = [];
+                isFirstTable = false;
+              }
+            };
+
+            data.items.forEach((item) => {
+              if ((item as any)._isSectionHeader) {
+                // Close previous table and start a new one for this subsection
+                closeTable();
+                itemIndex = 1;
+              } else if ((item as any)._isSubtotal || (item as any)._isSectionTotal) {
+                // Add subtotal row to current table
+                currentTable.push(`
+                  <tr style="font-weight: bold; background-color: #f5f5f5;">
+                    <td colspan="5" style="text-align: right;">${item.description}</td>
+                    <td class="amount-cell">${formatCurrency(item.line_total)}</td>
+                  </tr>
+                `);
+              } else {
+                // Regular item row
+                currentTable.push(`
+                  <tr>
+                    <td>${itemIndex}</td>
+                    <td class="description-cell">${item.description}</td>
+                    <td>${item.quantity}</td>
+                    <td>${(item as any).unit_of_measure || (item as any).unit || 'Item'}</td>
+                    <td class="amount-cell">${formatCurrency(item.unit_price)}</td>
+                    <td class="amount-cell">${formatCurrency(item.line_total)}</td>
+                  </tr>
+                `);
+                itemIndex++;
+              }
+            });
+
+            closeTable();
+            return tableHtml;
+          })() : `
           <table class="items-table">
             <thead>
               <tr>
@@ -3359,6 +3420,7 @@ export const generatePDF = async (data: DocumentData) => {
               `).join('')}
             </tbody>
           </table>
+          `}
         </div>
         ` : ''}
         


### PR DESCRIPTION
### Summary
This PR fixes the LCL BOQ PDF output so that each subsection (e.g., Materials, Labor) renders its own properly headed table, rather than sharing a single table across all sections.

### Problem
The LCL BOQ PDF (and the per-row LCL BOQ List PDF) was not correctly displaying table headers for each subsection. Each section (e.g., "SECTION A: Foundation") contains subsections like "1. Materials" and "2. Labor", but all items were rendered in a single flat table without per-subsection headers, making the document hard to read and improperly structured.

### Solution
A new `isLCLBOQ` flag was introduced and passed through the PDF generation pipeline. When this flag is active and the document type is `boq`, the items list is rendered as multiple split tables — one per subsection — each with its own column header row. Section headers trigger the closure of the current table and the opening of a new one.

### Key Changes
- Added `isLCLBOQ?: boolean` option to `BoqPdfOptions` interface in `boqPdfGenerator.ts` and forwarded it to the core `generatePDF` call.
- Set `isLCLBOQ: true` unconditionally in `lclBoqPdfGenerator.ts` so all LCL BOQ PDFs use the new rendering path.
- Added `isLCLBOQ?: boolean` to the `DocumentData` interface in `pdfGenerator.ts`.
- Implemented a table-splitting rendering block in `pdfGenerator.ts`: when `isLCLBOQ` is `true`, items are iterated and a new `<table>` with a full `<thead>` is opened each time a section header item is encountered, with subtotal rows and regular item rows handled appropriately within each table.
- Non-LCL BOQ documents continue to use the existing single-table rendering path, leaving all other document types unaffected.


---

<a href="https://builder.io/app/projects/faeace9c68f94a749288/shimmer-peak-jnj43chu"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://faeace9c68f94a749288-shimmer-peak-jnj43chu_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=faeace9c68f94a749288&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 277`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>faeace9c68f94a749288</projectId>-->
<!--<branchName>shimmer-peak-jnj43chu</branchName>-->