### PR TITLE
Add section/subsection headers to LCL template table

### DIFF
--- a/src/components/lcl/EditLCLBOQModal.tsx
+++ b/src/components/lcl/EditLCLBOQModal.tsx
@@ -40,7 +40,9 @@ interface InlineEdit {
 
 interface ItemSnapshot {
   section_id: string;
+  section_name?: string;
   subsection_id: string;
+  subsection_name?: string;
   item_number: string;
   description: string;
   unit: string;

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -618,7 +618,7 @@ export function LCLTemplateEditor({
                             {isFirstSubsection && (
                               <TableRow className="bg-gray-100 hover:bg-gray-100 cursor-default">
                                 <TableCell colSpan={7} className="text-sm font-bold text-gray-700 py-2">
-                                  SECTION {sectionLetter}: {section.section_name}
+                                  {section.section_name}
                                 </TableCell>
                               </TableRow>
                             )}

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -570,7 +570,11 @@ export function LCLTemplateEditor({
             {/* Subsections and items */}
             {expandedSections.has(section.section_id) && (
               <div className="border-t border-border">
-                {section.subsections.map((subsection) => (
+                {section.subsections.map((subsection, subsectionIndex) => {
+                  const sectionLetter = String.fromCharCode(65 + data.sections.findIndex(s => s.section_id === section.section_id));
+                  const isFirstSubsection = subsectionIndex === 0;
+
+                  return (
                   <div key={subsection.subsection_id}>
                     {/* Subsection header */}
                     <button
@@ -610,6 +614,22 @@ export function LCLTemplateEditor({
                             </TableRow>
                           </TableHeader>
                           <TableBody>
+                            {/* Section header - shown only for first subsection */}
+                            {isFirstSubsection && (
+                              <TableRow className="bg-gray-100 hover:bg-gray-100 cursor-default">
+                                <TableCell colSpan={7} className="text-sm font-bold text-gray-700 py-2">
+                                  SECTION {sectionLetter}: {section.section_name}
+                                </TableCell>
+                              </TableRow>
+                            )}
+
+                            {/* Subsection header */}
+                            <TableRow className="bg-gray-50 hover:bg-gray-50 cursor-default">
+                              <TableCell colSpan={7} className="text-sm font-semibold py-2 pl-8">
+                                → {subsection.subsection_name}
+                              </TableCell>
+                            </TableRow>
+
                             {subsection.items.map((item) => (
                               <TableRow
                                 key={item.id}
@@ -786,6 +806,15 @@ export function LCLTemplateEditor({
                               </TableRow>
                             ))}
 
+                            {/* Subsection subtotal */}
+                            <TableRow className="bg-gray-100 hover:bg-gray-100 cursor-default font-semibold">
+                              <TableCell colSpan={5} className="text-sm py-2"></TableCell>
+                              <TableCell className="text-right text-sm font-semibold py-2">
+                                Ksh{(totals[section.section_id]?.subsections[subsection.subsection_id] || 0).toLocaleString('en-KE', { maximumFractionDigits: 2 })}
+                              </TableCell>
+                              <TableCell></TableCell>
+                            </TableRow>
+
                             {/* Add new item row */}
                             {addingItemTo === subsection.subsection_id &&
                             editingItem ? (
@@ -913,7 +942,8 @@ export function LCLTemplateEditor({
                       </div>
                     )}
                   </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>

--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -149,7 +149,9 @@ export default function LCLTemplate() {
           subsection.items.forEach((item) => {
             itemsSnapshot.push({
               section_id: section.section_id,
+              section_name: section.section_name,
               subsection_id: subsection.subsection_id,
+              subsection_name: subsection.subsection_name,
               item_number: item.item_number,
               description: item.description,
               unit: item.unit,

--- a/src/utils/lclBoqPdfGenerator.ts
+++ b/src/utils/lclBoqPdfGenerator.ts
@@ -5,7 +5,9 @@ const safeN = (v: number | undefined) => (typeof v === 'number' && !isNaN(v) ? v
 
 export interface ItemSnapshot {
   section_id: string;
+  section_name?: string;
   subsection_id: string;
+  subsection_name?: string;
   item_number: string;
   description: string;
   unit: string;
@@ -143,16 +145,26 @@ export function reconstructHierarchicalDataFromSnapshot(
   sectionsMap.forEach((subsectionsMap, sectionId) => {
     const subsections: any[] = [];
     let sectionTotal = 0;
+    let preservedSectionName: string | undefined;
 
     subsectionsMap.forEach((items, subsectionId) => {
       let subtotal = 0;
+      let preservedSubsectionName: string | undefined;
 
-      const processedItems = items.map((item) => ({
-        ...item,
-        qty: safeN(item.qty),
-        rate: safeN(item.rate),
-        amount: safeN(item.qty) * safeN(item.rate),
-      }));
+      const processedItems = items.map((item) => {
+        if (!preservedSectionName && item.section_name) {
+          preservedSectionName = item.section_name;
+        }
+        if (!preservedSubsectionName && item.subsection_name) {
+          preservedSubsectionName = item.subsection_name;
+        }
+        return {
+          ...item,
+          qty: safeN(item.qty),
+          rate: safeN(item.rate),
+          amount: safeN(item.qty) * safeN(item.rate),
+        };
+      });
 
       processedItems.forEach((item) => {
         subtotal += item.amount;
@@ -160,7 +172,7 @@ export function reconstructHierarchicalDataFromSnapshot(
 
       subsections.push({
         subsection_id: subsectionId,
-        subsection_name: subsectionId,
+        subsection_name: preservedSubsectionName || subsectionId,
         items: processedItems,
         subtotal,
       });
@@ -171,7 +183,7 @@ export function reconstructHierarchicalDataFromSnapshot(
     const sectionLetter = sectionId.replace('section-', '').toUpperCase();
     sections.push({
       section_id: sectionId,
-      section_name: `SECTION ${sectionLetter}`,
+      section_name: preservedSectionName || `SECTION ${sectionLetter}`,
       subsections,
       total: sectionTotal,
     });


### PR DESCRIPTION
### Summary
This PR adds visible section and subsection header rows to the LCL Template table view and fixes missing section/subsection names in the PDF generator and edit modal.

### Problem
The LCL Template page displayed items in a flat table without any section or subsection headers, making it impossible to distinguish which section or subsection each item belonged to. Additionally, the PDF download from the LCL BOQ list page was missing correct section and subsection names (falling back to raw IDs), and the edit modal lacked proper section/subsection context.

### Solution
Section and subsection names are now propagated through the item snapshot data and used to reconstruct correct hierarchy names. Header rows are injected directly into the table body as styled separator rows, mirroring the structure shown in the PDF output.

### Key Changes
- **`LCLTemplateEditor.tsx`**: Injects a bold gray section header row (shown once per section, on the first subsection) and an indented subsection header row (`→ Subsection Name`) into each subsection's table body. Also adds a subsection subtotal row after each subsection's items.
- **`LCLTemplate.tsx`**: Includes `section_name` and `subsection_name` in the item snapshot payload so names are preserved when data is serialized.
- **`lclBoqPdfGenerator.ts`**: Updates `ItemSnapshot` interface to include optional `section_name` and `subsection_name` fields. The `reconstructHierarchicalDataFromSnapshot` function now reads these preserved names from snapshot items instead of falling back to raw IDs, fixing incorrect section/subsection labels in the PDF.
- **`EditLCLBOQModal.tsx`**: Adds `section_name` and `subsection_name` to the `ItemSnapshot` interface to align with the updated data shape.

---

<a href="https://builder.io/app/projects/33fd1e714b904bbc83e1/modern-ship-46yjg6pg"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://33fd1e714b904bbc83e1-modern-ship-46yjg6pg_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=33fd1e714b904bbc83e1&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 281`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>33fd1e714b904bbc83e1</projectId>-->
<!--<branchName>modern-ship-46yjg6pg</branchName>-->