### PR TITLE
Fix LCL BOQ section names in edit modal and PDF

### DIFF
--- a/src/components/lcl/EditLCLBOQModal.tsx
+++ b/src/components/lcl/EditLCLBOQModal.tsx
@@ -23,13 +23,14 @@ import { CheckCircle2, AlertCircle, Download } from 'lucide-react';
 import { useCurrentCompany } from '@/contexts/CompanyContext';
 import { useCustomers } from '@/hooks/useDatabase';
 import { downloadLCLBOQPDF } from '@/utils/lclBoqPdfGenerator';
-import { LCLHierarchicalData } from '@/types/lclTemplate';
+import { LCLHierarchicalData, LCLTemplateStructure } from '@/types/lclTemplate';
 
 interface EditLCLBOQModalProps {
   isOpen: boolean;
   onClose: () => void;
   boq: LCLBOQRecord;
   onSaved: () => Promise<void>;
+  templateStructure?: LCLTemplateStructure;
 }
 
 interface InlineEdit {
@@ -56,6 +57,7 @@ export function EditLCLBOQModal({
   onClose,
   boq,
   onSaved,
+  templateStructure,
 }: EditLCLBOQModalProps) {
   const [items, setItems] = useState<ItemSnapshot[]>([]);
   const [inlineEdits, setInlineEdits] = useState<{ [itemId: string]: InlineEdit }>({});
@@ -68,6 +70,20 @@ export function EditLCLBOQModal({
   const { currentCompany } = useCurrentCompany();
   const { data: customers } = useCustomers(currentCompany?.id || '');
 
+  // Helper function to get section name from template or items snapshot
+  const getSectionNameFromTemplate = (sectionId: string): string | undefined => {
+    if (!templateStructure || !templateStructure.structure_data?.sections) {
+      return undefined;
+    }
+
+    const match = sectionId?.match(/section_([a-z])/i);
+    if (!match) return undefined;
+
+    const sectionIndex = match[1].toUpperCase().charCodeAt(0) - 65; // Convert A->0, B->1, etc.
+    const section = templateStructure.structure_data.sections[sectionIndex];
+    return section?.name;
+  };
+
   const extractSections = (itemsSnapshot: ItemSnapshot[]): Array<{ letter: string; name?: string }> => {
     const sectionsMap = new Map<string, { letter: string; name?: string }>();
     itemsSnapshot.forEach((item) => {
@@ -75,9 +91,11 @@ export function EditLCLBOQModal({
       if (match) {
         const letter = match[1].toUpperCase();
         if (!sectionsMap.has(letter)) {
+          // Use section_name from snapshot, or fallback to template
+          const sectionName = item.section_name || getSectionNameFromTemplate(item.section_id);
           sectionsMap.set(letter, {
             letter,
-            name: item.section_name,
+            name: sectionName,
           });
         }
       }
@@ -97,7 +115,9 @@ export function EditLCLBOQModal({
       const match = item.section_id?.match(/section_([a-z])/i);
       return match && match[1].toUpperCase() === sectionLetter;
     });
-    return sectionItem?.section_name || `SECTION ${sectionLetter}`;
+    // Use section_name from snapshot, or fallback to template, or use generic name
+    const name = sectionItem?.section_name || getSectionNameFromTemplate(sectionItem?.section_id);
+    return name ? `SECTION ${sectionLetter}: ${name}` : `SECTION ${sectionLetter}`;
   };
 
   const reconstructHierarchicalData = (): LCLHierarchicalData => {
@@ -409,7 +429,7 @@ export function EditLCLBOQModal({
                     : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
-                {section.name ? `${section.letter}: ${section.name}` : `Section ${section.letter}`}
+                {section.name ? `${section.letter}: ${section.name}` : `SECTION ${section.letter}`}
               </button>
             ))}
           </div>

--- a/src/components/lcl/EditLCLBOQModal.tsx
+++ b/src/components/lcl/EditLCLBOQModal.tsx
@@ -68,16 +68,21 @@ export function EditLCLBOQModal({
   const { currentCompany } = useCurrentCompany();
   const { data: customers } = useCustomers(currentCompany?.id || '');
 
-  const extractSections = (itemsSnapshot: ItemSnapshot[]): string[] => {
-    const sectionsSet = new Set<string>();
+  const extractSections = (itemsSnapshot: ItemSnapshot[]): Array<{ letter: string; name?: string }> => {
+    const sectionsMap = new Map<string, { letter: string; name?: string }>();
     itemsSnapshot.forEach((item) => {
-      // Extract section letter from section_id (e.g., "section_a" -> "A")
       const match = item.section_id?.match(/section_([a-z])/i);
       if (match) {
-        sectionsSet.add(match[1].toUpperCase());
+        const letter = match[1].toUpperCase();
+        if (!sectionsMap.has(letter)) {
+          sectionsMap.set(letter, {
+            letter,
+            name: item.section_name,
+          });
+        }
       }
     });
-    return Array.from(sectionsSet).sort();
+    return Array.from(sectionsMap.values()).sort((a, b) => a.letter.localeCompare(b.letter));
   };
 
   const getItemsForSection = (sectionLetter: string): ItemSnapshot[] => {
@@ -87,12 +92,20 @@ export function EditLCLBOQModal({
     });
   };
 
+  const getSectionName = (sectionLetter: string): string => {
+    const sectionItem = items.find((item) => {
+      const match = item.section_id?.match(/section_([a-z])/i);
+      return match && match[1].toUpperCase() === sectionLetter;
+    });
+    return sectionItem?.section_name || `SECTION ${sectionLetter}`;
+  };
+
   const reconstructHierarchicalData = (): LCLHierarchicalData => {
     const sections: any[] = [];
     const sectionLetters = extractSections(items);
 
-    sectionLetters.forEach((letter) => {
-      const sectionItems = getItemsForSection(letter);
+    sectionLetters.forEach((sectionObj) => {
+      const sectionItems = getItemsForSection(sectionObj.letter);
       const subsectionsMap = new Map<string, ItemSnapshot[]>();
 
       sectionItems.forEach((item) => {
@@ -107,10 +120,17 @@ export function EditLCLBOQModal({
 
       subsectionsMap.forEach((subsectionItems, subsectionId) => {
         let subtotal = 0;
-        const processedItems = subsectionItems.map((item) => ({
-          ...item,
-          amount: item.qty * item.rate,
-        }));
+        let preservedSubsectionName: string | undefined;
+
+        const processedItems = subsectionItems.map((item) => {
+          if (!preservedSubsectionName && item.subsection_name) {
+            preservedSubsectionName = item.subsection_name;
+          }
+          return {
+            ...item,
+            amount: item.qty * item.rate,
+          };
+        });
 
         subsectionItems.forEach((item) => {
           subtotal += item.qty * item.rate;
@@ -118,7 +138,7 @@ export function EditLCLBOQModal({
 
         subsections.push({
           subsection_id: subsectionId,
-          subsection_name: subsectionId,
+          subsection_name: preservedSubsectionName || subsectionId,
           items: processedItems,
           subtotal,
         });
@@ -127,8 +147,8 @@ export function EditLCLBOQModal({
       });
 
       sections.push({
-        section_id: `section-${letter}`,
-        section_name: `SECTION ${letter}`,
+        section_id: `section-${sectionObj.letter}`,
+        section_name: sectionObj.name || `SECTION ${sectionObj.letter}`,
         subsections,
         total: sectionTotal,
       });
@@ -151,7 +171,7 @@ export function EditLCLBOQModal({
       inlineEditsRef.current = {};
       const sections = extractSections(boq.items_snapshot);
       if (sections.length > 0) {
-        setActiveSection(sections[0]);
+        setActiveSection(sections[0].letter);
       }
     }
   }, [isOpen, boq]);
@@ -353,7 +373,7 @@ export function EditLCLBOQModal({
               <DialogTitle>Edit LCL BOQ - {boq.number}</DialogTitle>
               {activeSection && (
                 <p className="text-sm text-muted-foreground mt-1">
-                  Section {activeSection}
+                  {getSectionName(activeSection)}
                 </p>
               )}
               {boq.id && (
@@ -378,18 +398,18 @@ export function EditLCLBOQModal({
         </DialogHeader>
 
         {sections.length > 0 && (
-          <div className="flex gap-2 border-b pb-2">
+          <div className="flex gap-2 border-b pb-2 overflow-x-auto">
             {sections.map((section) => (
               <button
-                key={section}
-                onClick={() => setActiveSection(section)}
-                className={`px-3 py-2 text-sm font-medium rounded-t border-b-2 transition-colors ${
-                  activeSection === section
+                key={section.letter}
+                onClick={() => setActiveSection(section.letter)}
+                className={`px-3 py-2 text-sm font-medium rounded-t border-b-2 transition-colors whitespace-nowrap ${
+                  activeSection === section.letter
                     ? 'border-primary text-primary'
                     : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
-                Section {section}
+                {section.name ? `${section.letter}: ${section.name}` : `Section ${section.letter}`}
               </button>
             ))}
           </div>
@@ -473,7 +493,7 @@ export function EditLCLBOQModal({
             <div className="flex justify-end border-t pt-4">
               <div className="text-right">
                 <div className="text-sm text-muted-foreground mb-2">
-                  Section {activeSection} Total
+                  {getSectionName(activeSection)} Total
                 </div>
                 <div className="text-2xl font-bold">
                   {currentSectionItems

--- a/src/pages/LCLBOQList.tsx
+++ b/src/pages/LCLBOQList.tsx
@@ -5,6 +5,8 @@ import { useToast } from '@/hooks/use-toast';
 import { useCurrentCompany } from '@/contexts/CompanyContext';
 import { lclBoqService, LCLBOQRecord } from '@/services/lclBoqService';
 import { useCustomers } from '@/hooks/useDatabase';
+import { lclTemplateService } from '@/services/lclTemplateService';
+import { LCLTemplateStructure } from '@/types/lclTemplate';
 import {
   Table,
   TableBody,
@@ -31,10 +33,26 @@ export default function LCLBOQList() {
   const [selectedBoq, setSelectedBoq] = useState<LCLBOQRecord | null>(null);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
+  const [templateStructure, setTemplateStructure] = useState<LCLTemplateStructure | undefined>();
 
   useEffect(() => {
     loadBoqs();
+    loadTemplateStructure();
   }, [companyId]);
+
+  const loadTemplateStructure = async () => {
+    if (!companyId) return;
+    try {
+      const structures = await lclTemplateService.getStructures(companyId);
+      const defaultStructure = structures.find(
+        (s) => s.name.toLowerCase().includes('default')
+      ) || structures[0];
+      setTemplateStructure(defaultStructure);
+    } catch (error) {
+      console.error('Error loading template structure:', error);
+      // Gracefully fail - modal will work with fallback
+    }
+  };
 
   const loadBoqs = async () => {
     if (!companyId) return;
@@ -287,6 +305,7 @@ export default function LCLBOQList() {
           onClose={() => setShowEditModal(false)}
           boq={selectedBoq}
           onSaved={handleEditSaved}
+          templateStructure={templateStructure}
         />
       )}
 

--- a/src/utils/lclBoqPdfGenerator.ts
+++ b/src/utils/lclBoqPdfGenerator.ts
@@ -120,6 +120,7 @@ function flattenLCLBOQItems(data: LCLHierarchicalData): Array<{
 /**
  * Reconstructs hierarchical data from a flat items snapshot.
  * Converts flat array of items back to the hierarchical structure expected by downloadLCLBOQPDF.
+ * Uses preserved section/subsection names from items, with fallback to generated names.
  */
 export function reconstructHierarchicalDataFromSnapshot(
   flatItems: ItemSnapshot[]
@@ -152,6 +153,7 @@ export function reconstructHierarchicalDataFromSnapshot(
       let preservedSubsectionName: string | undefined;
 
       const processedItems = items.map((item) => {
+        // Preserve section and subsection names from snapshot
         if (!preservedSectionName && item.section_name) {
           preservedSectionName = item.section_name;
         }
@@ -180,9 +182,10 @@ export function reconstructHierarchicalDataFromSnapshot(
       sectionTotal += subtotal;
     });
 
-    const sectionLetter = sectionId.replace('section-', '').toUpperCase();
+    const sectionLetter = sectionId.replace(/[^\w]/g, '').match(/[a-zA-Z]/)?.[0]?.toUpperCase() || 'A';
     sections.push({
       section_id: sectionId,
+      // Use preserved section name from snapshot, fallback to constructed name
       section_name: preservedSectionName || `SECTION ${sectionLetter}`,
       subsections,
       total: sectionTotal,


### PR DESCRIPTION
### Summary
This PR fixes the display of section and subsection names in the LCL BOQ edit modal and PDF generator, replacing generic labels like "SECTION A" with full descriptive names like "SECTION A: Foundation".

### Problem
When a BOQ was reconstructed from its `items_snapshot`, section and subsection names were lost. The edit modal displayed generic tab labels (e.g., "Section A") and the PDF generator produced section headers without descriptive names. This happened because the reconstruction logic hardcoded names like `SECTION ${letter}` instead of using the original names stored in the snapshot or template structure.

### Solution
The edit modal now reads `section_name` and `subsection_name` fields directly from the items snapshot, with a fallback to the `LCLTemplateStructure` passed in from the parent. The PDF generator's reconstruction utility was similarly updated to prefer preserved names from the snapshot before falling back to generated ones. The parent `LCLBOQList` page now loads and passes the template structure to the edit modal.

### Key Changes
- **`EditLCLBOQModal.tsx`**:
  - Added optional `templateStructure` prop (`LCLTemplateStructure`) to the modal interface
  - Refactored `extractSections` to return `{ letter, name }` objects instead of plain strings, sourcing names from `item.section_name` or the template structure
  - Added `getSectionNameFromTemplate` helper to look up section names by index from the template structure
  - Added `getSectionName` helper to format full section labels (e.g., `SECTION A: Foundation`)
  - Updated `reconstructHierarchicalData` to preserve `subsection_name` from snapshot items
  - Updated section tab rendering to display full descriptive names with `whitespace-nowrap` and horizontal scroll support
  - Updated dialog header and section total label to use full section names

- **`LCLBOQList.tsx`**:
  - Loads the company's template structure on mount via `lclTemplateService.getStructures`
  - Passes `templateStructure` to `EditLCLBOQModal` as a fallback name source

- **`lclBoqPdfGenerator.ts`**:
  - Updated `reconstructHierarchicalDataFromSnapshot` to use preserved `section_name` and `subsection_name` from snapshot items, falling back to generated names
  - Fixed section letter extraction regex to be more robust


---

<a href="https://builder.io/app/projects/d7d2d6c3be2241bc8b1c/twinkle-record-bkspknbn"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://d7d2d6c3be2241bc8b1c-twinkle-record-bkspknbn_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=d7d2d6c3be2241bc8b1c&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 282`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7d2d6c3be2241bc8b1c</projectId>-->
<!--<branchName>twinkle-record-bkspknbn</branchName>-->