### PR TITLE
Fix LCL BOQ PDF section and subsection layout

### DIFF
--- a/src/utils/lclBoqPdfGenerator.ts
+++ b/src/utils/lclBoqPdfGenerator.ts
@@ -33,6 +33,7 @@ function flattenLCLBOQItems(data: LCLHierarchicalData): Array<{
   _isSectionHeader?: boolean;
   _isSubtotal?: boolean;
   _isSectionTotal?: boolean;
+  _isFirstSubsection?: boolean;
 }> {
   const flatItems: Array<{
     description: string;
@@ -43,6 +44,7 @@ function flattenLCLBOQItems(data: LCLHierarchicalData): Array<{
     _isSectionHeader?: boolean;
     _isSubtotal?: boolean;
     _isSectionTotal?: boolean;
+    _isFirstSubsection?: boolean;
   }> = [];
 
   data.sections.forEach((section, sectionIndex) => {
@@ -61,7 +63,9 @@ function flattenLCLBOQItems(data: LCLHierarchicalData): Array<{
     });
 
     // Add subsections and items
-    section.subsections.forEach((subsection) => {
+    section.subsections.forEach((subsection, subsectionIndex) => {
+      const isFirstSubsection = subsectionIndex === 0;
+
       // Add subsection header
       flatItems.push({
         description: `Subsection ${subsection.subsection_name}`,
@@ -71,6 +75,7 @@ function flattenLCLBOQItems(data: LCLHierarchicalData): Array<{
         unit_of_measure: undefined,
         _isSectionHeader: true,
         _isSubtotal: false,
+        _isFirstSubsection: isFirstSubsection,
       });
 
       // Add items

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -924,22 +924,16 @@ export const generatePDF = async (data: DocumentData) => {
     let sectionCount = 0;
 
     if (data.isLCLBOQ) {
-      // LCL BOQ: render section/subsection headers as div separators with per-subsection tables
+      // LCL BOQ: render section/subsection headers as table rows (not separate divs)
       let currentTableRows: string[] = [];
-      let pendingHeaders: string[] = [];
-      let isFirstTable = true;
+      let isFirstSection = true;
       let itemIndex = 0;
+      let sectionHeaderRendered = false;
 
       const closeTable = () => {
-        if (currentTableRows.length > 0 || pendingHeaders.length > 0) {
-          const headersHtml = pendingHeaders.map(h =>
-            `<div style="font-weight: bold; margin-top: 16px; margin-bottom: 8px; padding: 8px 10px; background-color: #f4f4f4; border-left: 3px solid #333; font-size: 11px;">${h}</div>`
-          ).join('');
-          pendingHeaders = [];
-
-          tablesHtml += `<div class="section-block" style="page-break-before: ${isFirstTable ? 'avoid' : 'always'} !important; page-break-inside: avoid !important; break-before: ${isFirstTable ? 'avoid' : 'page'};">
-            ${headersHtml}
-            <table class="items" style="margin-bottom: 8mm; margin-left: 15mm; margin-right: 15mm; width: calc(100% - 30mm);${!isFirstTable ? ' margin-top: 8px;' : ''}">
+        if (currentTableRows.length > 0) {
+          tablesHtml += `<div class="section-block" style="page-break-before: ${isFirstSection ? 'avoid' : 'always'} !important; page-break-inside: avoid !important; break-before: ${isFirstSection ? 'avoid' : 'page'};">
+            <table class="items" style="margin-bottom: 8mm; margin-left: 15mm; margin-right: 15mm; width: calc(100% - 30mm);${!isFirstSection ? ' margin-top: 8px;' : ''}">
               <thead>
                 <tr>
                   <th style="width:5%; font-weight: bold;">#</th>
@@ -956,21 +950,42 @@ export const generatePDF = async (data: DocumentData) => {
             </table>
           </div>`;
           currentTableRows = [];
-          isFirstTable = false;
+          isFirstSection = false;
+          itemIndex = 0;
+          sectionHeaderRendered = false;
         }
       };
 
       (data.items || []).forEach((item) => {
         if ((item as any)._isSectionHeader) {
-          closeTable();
-          pendingHeaders.push(item.description);
-          itemIndex = 1;
+          const isFirstSubsection = (item as any)._isFirstSubsection;
+
+          // For section headers, reset item counter
+          if (!sectionHeaderRendered) {
+            itemIndex = 1;
+            sectionHeaderRendered = true;
+          }
+
+          // Render header as table row with appropriate styling
+          const headerStyle = isFirstSubsection
+            ? "font-weight: bold; background-color: #333; color: white; padding: 8px 10px;"
+            : "font-weight: bold; background-color: #f4f4f4; color: #333; padding: 8px 10px;";
+
+          currentTableRows.push(`<tr style="${headerStyle}">
+            <td colspan="6" style="text-align: left; padding: 8px 10px;">${item.description}</td>
+          </tr>`);
         } else if ((item as any)._isSubtotal || (item as any)._isSectionTotal) {
+          // Section/subsection total is a signal to close the table
           currentTableRows.push(`<tr style="font-weight: bold; background-color: #f5f5f5;">
             <td style="padding: 6px 8px;"></td>
             <td colspan="4" style="text-align: right; padding: 6px 8px;">${item.description}</td>
             <td style="text-align: right; padding: 6px 8px; font-weight: 700;">${formatCurrency(item.line_total)}</td>
           </tr>`);
+
+          // Close table after section total (each section gets its own table)
+          if ((item as any)._isSectionTotal) {
+            closeTable();
+          }
         } else {
           currentTableRows.push(`<tr>
             <td style="padding: 4px 8px; text-align: center;">${itemIndex}</td>


### PR DESCRIPTION
### Summary
Fixes the LCL BOQ PDF layout so that section titles and subsection headers are rendered as table rows within a unified table, rather than as separate standalone div elements above each subsection table.

### Problem
Section titles were being rendered in their own separate div blocks, disconnected from the subsection content below them. This caused the section name to appear visually detached from the first subsection, and each subsection was generating its own isolated table, breaking the intended layout.

### Solution
Section and subsection headers are now rendered as styled table rows (`<tr>`) within the same table as their items. The first subsection header receives a distinct dark background style (to represent the section title), while subsequent subsection headers use a lighter style. A single table is closed per section (on `_isSectionTotal`), ensuring all subsections within a section share one cohesive table.

### Key Changes
- Added `_isFirstSubsection` flag in `flattenLCLBOQItems` to distinguish the first subsection header within each section
- Removed `pendingHeaders` div-based rendering in `pdfGenerator.ts`; headers are now injected as `<tr colspan="6">` rows directly into the current table
- First subsection header styled with dark background (`#333`, white text) to visually represent the section title
- Subsequent subsection headers styled with light background (`#f4f4f4`, dark text)
- Table is now closed only on `_isSectionTotal`, ensuring all subsections of a section are grouped into one table
- `itemIndex` and `sectionHeaderRendered` state properly reset between sections


---

<a href="https://builder.io/app/projects/3b06f6db3add4268a4a0/twin-zone-7oia1qtl"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://3b06f6db3add4268a4a0-twin-zone-7oia1qtl_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=3b06f6db3add4268a4a0&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 283`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b06f6db3add4268a4a0</projectId>-->
<!--<branchName>twin-zone-7oia1qtl</branchName>-->