### PR TITLE
Fix debounce closure bug in LCL template inline edits

### DIFF
--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -73,6 +73,7 @@ export function LCLTemplateEditor({
   const [lastSavedTime, setLastSavedTime] = useState<string | null>(null);
   const debounceTimers = useRef<{ [itemId: string]: NodeJS.Timeout }>({});
   const autosaveTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const latestInlineEditsRef = useRef<{ [itemId: string]: InlineEdit }>({});
   const { toast } = useToast();
 
   // Format number to remove unnecessary decimals (1.00 → 1, 1.50 → 1.5)
@@ -214,14 +215,24 @@ export function LCLTemplateEditor({
         [itemId]: { ...prev[itemId], qty },
       };
 
-      // Debounce save - capture current rate value when timer executes
+      // Save first edit to localStorage immediately for recovery
+      if (Object.keys(prev).length === 0) {
+        try {
+          saveDraftToLocalStorage(data.structure_id, newEdits);
+        } catch (error) {
+          console.error('Failed to save first edit:', error);
+        }
+      }
+
+      // Debounce save - read both qty and rate from latest ref when timer executes
       if (debounceTimers.current[itemId]) {
         clearTimeout(debounceTimers.current[itemId]);
       }
 
       debounceTimers.current[itemId] = setTimeout(() => {
-        const currentRate = newEdits[itemId]?.rate;
-        saveInlineEdit(itemId, qty, currentRate);
+        const latestQty = latestInlineEditsRef.current[itemId]?.qty ?? qty;
+        const latestRate = latestInlineEditsRef.current[itemId]?.rate;
+        saveInlineEdit(itemId, latestQty, latestRate);
       }, 500);
 
       return newEdits;
@@ -238,14 +249,24 @@ export function LCLTemplateEditor({
         [itemId]: { ...prev[itemId], rate },
       };
 
-      // Debounce save - capture current qty value when timer executes
+      // Save first edit to localStorage immediately for recovery
+      if (Object.keys(prev).length === 0) {
+        try {
+          saveDraftToLocalStorage(data.structure_id, newEdits);
+        } catch (error) {
+          console.error('Failed to save first edit:', error);
+        }
+      }
+
+      // Debounce save - read both qty and rate from latest ref when timer executes
       if (debounceTimers.current[itemId]) {
         clearTimeout(debounceTimers.current[itemId]);
       }
 
       debounceTimers.current[itemId] = setTimeout(() => {
-        const currentQty = newEdits[itemId]?.qty;
-        saveInlineEdit(itemId, currentQty, rate);
+        const latestQty = latestInlineEditsRef.current[itemId]?.qty;
+        const latestRate = latestInlineEditsRef.current[itemId]?.rate ?? rate;
+        saveInlineEdit(itemId, latestQty, latestRate);
       }, 500);
 
       return newEdits;
@@ -303,6 +324,18 @@ export function LCLTemplateEditor({
       });
     }
   };
+
+  // Keep latest edits ref in sync with state for debounce callbacks
+  useEffect(() => {
+    latestInlineEditsRef.current = inlineEdits;
+  }, [inlineEdits]);
+
+  // Mark as unsaved when user makes new edits (after mount/load)
+  useEffect(() => {
+    if (Object.keys(inlineEdits).length > 0) {
+      setHasUnsavedChanges(true);
+    }
+  }, [inlineEdits]);
 
   // Load draft from localStorage on mount
   useEffect(() => {


### PR DESCRIPTION
### Summary
Fixes a stale closure bug in the LCL Template Editor where debounced inline edits for QTY and Rate fields could overwrite each other with outdated values, causing the UI to revert to previously saved data after a backend refresh.

### Problem
When a user edited QTY and then Rate (or vice versa) within 500ms of each other, the debounce timer for the first field would fire with a stale snapshot of the second field's value — because the closure captured state at the time the timer was created, not at the time it executed. This caused the backend to receive incorrect data, and when `onDataUpdated()` refreshed the component, the UI would fall back to the old saved values, making it appear as though edits were lost.

### Solution
Introduced a `latestInlineEditsRef` that stays in sync with the `inlineEdits` state via a `useEffect`. Debounce callbacks now read both `qty` and `rate` from this ref at execution time, ensuring they always use the most up-to-date values regardless of when the timer fires.

### Key Changes
- **`latestInlineEditsRef`**: A new `useRef` that mirrors `inlineEdits` state, updated synchronously via `useEffect` on every state change.
- **Debounce callbacks updated**: `handleInlineQtyChange` and `handleInlineRateChange` now read both `qty` and `rate` from `latestInlineEditsRef.current` when the timer fires, eliminating stale closure captures.
- **First-edit localStorage save**: When the first inline edit is made (i.e., `inlineEdits` was previously empty), the draft is immediately persisted to `localStorage` for early recovery.
- **`hasUnsavedChanges` tracking**: A new `useEffect` sets `hasUnsavedChanges = true` whenever `inlineEdits` is non-empty, ensuring the save status indicator reflects pending changes correctly.


---

<a href="https://builder.io/app/projects/34a62ce91af142d99125/meta-league-gdsam6ya"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://34a62ce91af142d99125-meta-league-gdsam6ya_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=34a62ce91af142d99125&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 285`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>34a62ce91af142d99125</projectId>-->
<!--<branchName>meta-league-gdsam6ya</branchName>-->