### PR TITLE
Fix LCL template auto-save status stuck on unsaved changes

### DIFF
--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -309,6 +309,8 @@ export function LCLTemplateEditor({
         // Clear draft if no more unsaved edits
         if (Object.keys(updated).length === 0) {
           clearDraftFromLocalStorage(data.structure_id);
+          setHasUnsavedChanges(false);
+          setLastSavedTime(new Date().toISOString());
         }
 
         return updated;

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -378,6 +378,13 @@ export function LCLTemplateEditor({
     };
   }, [inlineEdits, data.structure_id]);
 
+  // Clear unsaved status when all inline edits have been saved
+  useEffect(() => {
+    if (Object.keys(inlineEdits).length === 0) {
+      setHasUnsavedChanges(false);
+    }
+  }, [inlineEdits]);
+
   // Cleanup debounce timers on unmount
   useEffect(() => {
     return () => {

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -217,6 +217,7 @@ export function LCLTemplateEditor({
 
       // Save first edit to localStorage immediately for recovery
       if (Object.keys(prev).length === 0) {
+        setHasUnsavedChanges(true);
         try {
           saveDraftToLocalStorage(data.structure_id, newEdits);
         } catch (error) {
@@ -251,6 +252,7 @@ export function LCLTemplateEditor({
 
       // Save first edit to localStorage immediately for recovery
       if (Object.keys(prev).length === 0) {
+        setHasUnsavedChanges(true);
         try {
           saveDraftToLocalStorage(data.structure_id, newEdits);
         } catch (error) {
@@ -332,12 +334,6 @@ export function LCLTemplateEditor({
     latestInlineEditsRef.current = inlineEdits;
   }, [inlineEdits]);
 
-  // Mark as unsaved when user makes new edits, clear when all saved
-  useEffect(() => {
-    const hasEdits = Object.keys(inlineEdits).length > 0;
-    console.log('[LCLEditor] inlineEdits changed, hasEdits:', hasEdits, 'inlineEdits:', inlineEdits);
-    setHasUnsavedChanges(hasEdits);
-  }, [inlineEdits]);
 
   // Load draft from localStorage on mount
   useEffect(() => {

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -332,11 +332,9 @@ export function LCLTemplateEditor({
 
   // Mark as unsaved when user makes new edits, clear when all saved
   useEffect(() => {
-    if (Object.keys(inlineEdits).length > 0) {
-      setHasUnsavedChanges(true);
-    } else {
-      setHasUnsavedChanges(false);
-    }
+    const hasEdits = Object.keys(inlineEdits).length > 0;
+    console.log('[LCLEditor] inlineEdits changed, hasEdits:', hasEdits, 'inlineEdits:', inlineEdits);
+    setHasUnsavedChanges(hasEdits);
   }, [inlineEdits]);
 
   // Load draft from localStorage on mount

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -217,12 +217,15 @@ export function LCLTemplateEditor({
 
       // Save first edit to localStorage immediately for recovery
       if (Object.keys(prev).length === 0) {
+        console.log(`[EDIT] First edit added - itemId: ${itemId}, qty: ${qty}, setting hasUnsavedChanges=true`);
         setHasUnsavedChanges(true);
         try {
           saveDraftToLocalStorage(data.structure_id, newEdits);
         } catch (error) {
           console.error('Failed to save first edit:', error);
         }
+      } else {
+        console.log(`[EDIT] Qty changed - itemId: ${itemId}, qty: ${qty}, total edits: ${Object.keys(prev).length}`);
       }
 
       // Debounce save - read both qty and rate from latest ref when timer executes
@@ -231,6 +234,7 @@ export function LCLTemplateEditor({
       }
 
       debounceTimers.current[itemId] = setTimeout(() => {
+        console.log(`[DEBOUNCE] Timer fired for itemId: ${itemId}`);
         const latestQty = latestInlineEditsRef.current[itemId]?.qty ?? qty;
         const latestRate = latestInlineEditsRef.current[itemId]?.rate;
         saveInlineEdit(itemId, latestQty, latestRate);
@@ -252,12 +256,15 @@ export function LCLTemplateEditor({
 
       // Save first edit to localStorage immediately for recovery
       if (Object.keys(prev).length === 0) {
+        console.log(`[EDIT] First edit added - itemId: ${itemId}, rate: ${rate}, setting hasUnsavedChanges=true`);
         setHasUnsavedChanges(true);
         try {
           saveDraftToLocalStorage(data.structure_id, newEdits);
         } catch (error) {
           console.error('Failed to save first edit:', error);
         }
+      } else {
+        console.log(`[EDIT] Rate changed - itemId: ${itemId}, rate: ${rate}, total edits: ${Object.keys(prev).length}`);
       }
 
       // Debounce save - read both qty and rate from latest ref when timer executes
@@ -266,6 +273,7 @@ export function LCLTemplateEditor({
       }
 
       debounceTimers.current[itemId] = setTimeout(() => {
+        console.log(`[DEBOUNCE] Timer fired for itemId: ${itemId}`);
         const latestQty = latestInlineEditsRef.current[itemId]?.qty;
         const latestRate = latestInlineEditsRef.current[itemId]?.rate ?? rate;
         saveInlineEdit(itemId, latestQty, latestRate);
@@ -276,6 +284,7 @@ export function LCLTemplateEditor({
   };
 
   const saveInlineEdit = async (itemId: string, newQty?: number, newRate?: number) => {
+    console.log(`[SAVE] saveInlineEdit starting for itemId: ${itemId}, newQty: ${newQty}, newRate: ${newRate}`);
     try {
       const edit = inlineEdits[itemId];
       const qtyToSave = newQty !== undefined ? newQty : edit?.qty;
@@ -294,7 +303,10 @@ export function LCLTemplateEditor({
         if (currentItem) break;
       }
 
-      if (!currentItem) return;
+      if (!currentItem) {
+        console.log(`[SAVE] Item not found: ${itemId}`);
+        return;
+      }
 
       await lclTemplateService.updateItem(itemId, {
         description: currentItem.description,
@@ -303,13 +315,17 @@ export function LCLTemplateEditor({
         default_rate: rateToSave !== undefined ? rateToSave : currentItem.default_rate,
       });
 
+      console.log(`[SAVE] Database save completed for itemId: ${itemId}`);
+
       // Clear the inline edit after successful save
       setInlineEdits((prev) => {
         const updated = { ...prev };
         delete updated[itemId];
+        console.log(`[SAVE] Removing edit from state for itemId: ${itemId}, remaining edits: ${Object.keys(updated).length}`);
 
         // Clear draft if no more unsaved edits
         if (Object.keys(updated).length === 0) {
+          console.log(`[SAVE] No more edits, clearing draft and setting hasUnsavedChanges=false`);
           clearDraftFromLocalStorage(data.structure_id);
           setHasUnsavedChanges(false);
           setLastSavedTime(new Date().toISOString());
@@ -320,6 +336,7 @@ export function LCLTemplateEditor({
 
       await onDataUpdated();
     } catch (error) {
+      console.error(`[SAVE] Error saving itemId: ${itemId}`, error);
       toast({
         title: 'Error',
         description:

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -330,10 +330,12 @@ export function LCLTemplateEditor({
     latestInlineEditsRef.current = inlineEdits;
   }, [inlineEdits]);
 
-  // Mark as unsaved when user makes new edits (after mount/load)
+  // Mark as unsaved when user makes new edits, clear when all saved
   useEffect(() => {
     if (Object.keys(inlineEdits).length > 0) {
       setHasUnsavedChanges(true);
+    } else {
+      setHasUnsavedChanges(false);
     }
   }, [inlineEdits]);
 
@@ -377,13 +379,6 @@ export function LCLTemplateEditor({
       }
     };
   }, [inlineEdits, data.structure_id]);
-
-  // Clear unsaved status when all inline edits have been saved
-  useEffect(() => {
-    if (Object.keys(inlineEdits).length === 0) {
-      setHasUnsavedChanges(false);
-    }
-  }, [inlineEdits]);
 
   // Cleanup debounce timers on unmount
   useEffect(() => {

--- a/src/components/lclTemplate/LCLTemplateSaveIndicator.tsx
+++ b/src/components/lclTemplate/LCLTemplateSaveIndicator.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 interface LCLTemplateSaveIndicatorProps {
   isSaving: boolean;
   hasUnsavedChanges: boolean;
@@ -9,11 +11,17 @@ export function LCLTemplateSaveIndicator({
   hasUnsavedChanges,
   lastSavedTime,
 }: LCLTemplateSaveIndicatorProps) {
+  useEffect(() => {
+    console.log(`[UI] SaveIndicator render - isSaving: ${isSaving}, hasUnsavedChanges: ${hasUnsavedChanges}, lastSavedTime: ${lastSavedTime}`);
+  }, [isSaving, hasUnsavedChanges, lastSavedTime]);
+
   if (isSaving) {
+    console.log(`[UI] Rendering "Saving draft..." status`);
     return <span className="text-xs text-amber-600">Saving draft...</span>;
   }
 
   if (hasUnsavedChanges) {
+    console.log(`[UI] Rendering "Unsaved changes" status`);
     return <span className="text-xs text-orange-600">Unsaved changes</span>;
   }
 
@@ -22,8 +30,10 @@ export function LCLTemplateSaveIndicator({
       hour: '2-digit',
       minute: '2-digit',
     });
+    console.log(`[UI] Rendering "Saved at ${time}" status`);
     return <span className="text-xs text-green-600">Saved at {time}</span>;
   }
 
+  console.log(`[UI] Rendering no status`);
   return null;
 }


### PR DESCRIPTION
### Summary
Fixes the LCL template editor where the save status indicator was permanently stuck on "Unsaved changes" even after edits were successfully persisted to the database. Adds diagnostic logging throughout the save flow to aid debugging.

### Problem
The save status indicator in the LCL template editor never transitioned away from "Unsaved changes" after edits were saved. The `hasUnsavedChanges` flag was being set to `true` reactively via a `useEffect` watching `inlineEdits`, but was never reliably set back to `false` after a successful save, causing the UI to always show "Unsaved changes".

### Solution
Moved `setHasUnsavedChanges(true)` directly into the edit handler (on first edit detection) and `setHasUnsavedChanges(false)` + `setLastSavedTime(...)` directly into the post-save cleanup logic. Removed the `useEffect` that was previously responsible for setting the unsaved flag, which was causing the state to be re-set on every render cycle. Added `console.log` statements throughout the edit and save pipeline to trace state transitions.

### Key Changes
- **Removed** the `useEffect` that set `hasUnsavedChanges = true` whenever `inlineEdits` was non-empty — this was preventing the flag from ever clearing
- **Added** `setHasUnsavedChanges(true)` directly in the qty and rate change handlers when the first edit is detected
- **Added** `setHasUnsavedChanges(false)` and `setLastSavedTime(new Date().toISOString())` inside `saveInlineEdit` after all edits are cleared from state
- **Added** detailed `console.log` statements in `LCLTemplateEditor` (edit handlers, debounce timers, save function) and `LCLTemplateSaveIndicator` (render states) to trace the full save lifecycle


---

<a href="https://builder.io/app/projects/40ff44d9308741f88b65/tropical-society-7hgqfrh5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://40ff44d9308741f88b65-tropical-society-7hgqfrh5_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=40ff44d9308741f88b65&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 287`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>40ff44d9308741f88b65</projectId>-->
<!--<branchName>tropical-society-7hgqfrh5</branchName>-->