### PR TITLE
Persist LCL BOQ items and improve Add Item UI

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -680,7 +680,7 @@ function AddItemRow({
             onClick={() => onConfirm(description, unit, parseFloat(qty || '0'), parseFloat(rate || '0'))}
             className="h-7 text-xs bg-green-600 hover:bg-green-700 text-white"
           >
-            Confirm Addition
+            Confirm
           </Button>
           <Button
             size="sm"

--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -13,6 +13,7 @@ import { useToast } from '@/hooks/use-toast';
 import { AlertCircle, ChevronRight, Plus, Trash2 } from 'lucide-react';
 import { LCLHierarchicalData, LCLTemplateStructure } from '@/types/lclTemplate';
 import { ConfirmationDialog } from '@/components/ConfirmationDialog';
+import { lclBoqService } from '@/services/lclBoqService';
 
 export interface ItemSnapshot {
   section_id: string;
@@ -46,6 +47,8 @@ export interface LCLBOQItemEditorHandle {
 interface LCLBOQItemEditorProps {
   data: LCLHierarchicalData;
   templateStructure?: LCLTemplateStructure;
+  companyId?: string;
+  initialItems?: ItemSnapshot[];
 }
 
 const getDraftKey = (structureId: string) => `lcl_boq_creation_draft_${structureId}`;
@@ -59,6 +62,8 @@ interface AutosaveDraft {
 export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEditorProps>(function LCLBOQItemEditor({
   data,
   templateStructure,
+  companyId,
+  initialItems,
 }: LCLBOQItemEditorProps, ref) {
   const [items, setItems] = useState<ItemSnapshot[]>([]);
   const [inlineEdits, setInlineEdits] = useState<{ [itemId: string]: InlineEdit }>({});
@@ -153,6 +158,11 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
       if (restoredLastSavedAt) {
         setLastSavedTime(restoredLastSavedAt);
       }
+    } else if (initialItems && initialItems.length > 0) {
+      // Use provided initial items (from previously-saved BOQ)
+      setItems(initialItems);
+      setInlineEdits({});
+      inlineEditsRef.current = {};
     } else {
       setItems(flattenHierarchyToSnapshot(data));
       setInlineEdits({});
@@ -312,7 +322,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     setDraftPending(true);
   };
 
-  const confirmAddItem = (description: string, unit: string, qty: number, rate: number) => {
+  const confirmAddItem = async (description: string, unit: string, qty: number, rate: number) => {
     if (!addItemForm) return;
     setDraftPending(true);
     const section = data.sections.find(
@@ -344,7 +354,30 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
 
     setItems((prev) => [...prev, newItem]);
     setAddItemForm(null);
-    toast({ title: 'Success', description: 'Item added.' });
+
+    // Persist to database immediately if companyId is provided
+    if (companyId) {
+      try {
+        const updatedItems = [...items, newItem];
+        // Save draft BOQ with updated items
+        await lclBoqService.autosaveLCLBOQDraft({
+          company_id: companyId,
+          number: 'DRAFT',
+          items_snapshot: updatedItems,
+          status: 'draft',
+        });
+        toast({ title: 'Success', description: 'Item added and saved.' });
+      } catch (error) {
+        console.error('Failed to persist item:', error);
+        toast({
+          title: 'Warning',
+          description: 'Item added locally but failed to save to database.',
+          variant: 'destructive',
+        });
+      }
+    } else {
+      toast({ title: 'Success', description: 'Item added.' });
+    }
   };
 
   // Group items by section for rendering
@@ -531,9 +564,8 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                                 <TableCell colSpan={7} className="p-1">
                                   <Button
                                     size="sm"
-                                    variant="ghost"
+                                    className="text-xs w-full bg-green-600 hover:bg-green-700 text-white"
                                     onClick={() => handleAddItem(entry.subsectionId, sectionLetter)}
-                                    className="text-xs text-muted-foreground w-full"
                                   >
                                     <Plus className="h-3 w-3 mr-1" /> Add Item
                                   </Button>
@@ -591,7 +623,7 @@ function AddItemRow({
   onConfirm,
   onCancel,
 }: {
-  onConfirm: (description: string, unit: string, qty: number, rate: number) => void;
+  onConfirm: (description: string, unit: string, qty: number, rate: number) => void | Promise<void>;
   onCancel: () => void;
 }) {
   const [description, setDescription] = useState('New item');
@@ -645,11 +677,10 @@ function AddItemRow({
         <div className="flex gap-1">
           <Button
             size="sm"
-            variant="default"
             onClick={() => onConfirm(description, unit, parseFloat(qty || '0'), parseFloat(rate || '0'))}
-            className="h-7 text-xs"
+            className="h-7 text-xs bg-green-600 hover:bg-green-700 text-white"
           >
-            Add
+            Confirm Addition
           </Button>
           <Button
             size="sm"

--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -7,7 +7,7 @@ import { useCurrentCompany } from '@/contexts/CompanyContext';
 import { useCustomers } from '@/hooks/useDatabase';
 import { lclTemplateService } from '@/services/lclTemplateService';
 import { LCLHierarchicalData } from '@/types/lclTemplate';
-import { LCLBOQItemEditor, LCLBOQItemEditorHandle } from '@/components/lcl/LCLBOQItemEditor';
+import { LCLBOQItemEditor, LCLBOQItemEditorHandle, ItemSnapshot } from '@/components/lcl/LCLBOQItemEditor';
 import { lclBoqService, LCLBOQRecord } from '@/services/lclBoqService';
 import { generateNextBOQNumber } from '@/utils/boqNumberGenerator';
 import { downloadLCLBOQPDF, reconstructHierarchicalDataFromSnapshot } from '@/utils/lclBoqPdfGenerator';
@@ -41,6 +41,8 @@ export default function LCLTemplate() {
   const editorRef = useRef<LCLBOQItemEditorHandle>(null);
   const headerAutosaveRef = useRef<NodeJS.Timeout | null>(null);
 
+  const [initialItems, setInitialItems] = useState<ItemSnapshot[]>([]);
+
   const loadLCLBOQData = async () => {
     if (!companyId) return;
 
@@ -67,6 +69,18 @@ export default function LCLTemplate() {
       const data =
         await lclTemplateService.getHierarchicalData(lclDefaultStructure.id);
       setHierarchicalData(data);
+
+      // Load previously-added items from the most recent BOQ (saved or draft)
+      try {
+        const boqs = await lclBoqService.getLCLBOQs(companyId);
+        // Get the most recent BOQ with items
+        const latestBoq = boqs[0];
+        if (latestBoq && latestBoq.items_snapshot && latestBoq.items_snapshot.length > 0) {
+          setInitialItems(latestBoq.items_snapshot);
+        }
+      } catch (itemsError) {
+        console.log('Note: Could not load previous items:', itemsError);
+      }
 
       // Generate next BOQ number - checks both boqs and lcl_boqs tables
       try {
@@ -410,6 +424,8 @@ export default function LCLTemplate() {
         ref={editorRef}
         data={hierarchicalData}
         templateStructure={undefined}
+        companyId={companyId}
+        initialItems={initialItems}
       />
     </div>
   );


### PR DESCRIPTION
### Summary
This PR improves the LCL Template's item management by persisting newly added items to the database immediately and pre-loading previously saved items when the template is reopened. It also updates the UI to make the "Add Item" and "Confirm" buttons more visible with a green style.

### Problem
Items added in the LCL BOQ Item Editor were not persisted to the database, meaning they were lost on page reload. Additionally, the "Add Item" button lacked visual prominence, and the confirmation button label was unclear.

### Solution
- On item addition, the editor now calls `lclBoqService.autosaveLCLBOQDraft` immediately to persist the updated item list to the database.
- On page load, the most recent BOQ's `items_snapshot` is fetched and passed to the editor as `initialItems`, so previously added items are restored.
- The "Add Item" and "Confirm" buttons are styled green for better visibility, and the confirm button label is updated from "Add" to "Confirm".

### Key Changes
- **`LCLBOQItemEditor.tsx`**:
  - Added `companyId` and `initialItems` props to the editor component.
  - `confirmAddItem` is now `async` and calls `lclBoqService.autosaveLCLBOQDraft` to persist items immediately when `companyId` is provided.
  - If `initialItems` are provided (and no local draft exists), they are used to seed the editor state instead of flattening the hierarchy from scratch.
  - "Add Item" button changed from `ghost` variant to solid green (`bg-green-600 hover:bg-green-700 text-white`).
  - Confirm button changed to green styling and relabeled from "Add" to "Confirm".
- **`LCLTemplate.tsx`**:
  - Added `initialItems` state populated by fetching the most recent LCL BOQ on load.
  - Passes `companyId` and `initialItems` down to `LCLBOQItemEditor`.


---

<a href="https://builder.io/app/projects/6fbeec27c89748709973/pseudo-molecule-gppnrqyi"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://6fbeec27c89748709973-pseudo-molecule-gppnrqyi_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=6fbeec27c89748709973&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 288`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6fbeec27c89748709973</projectId>-->
<!--<branchName>pseudo-molecule-gppnrqyi</branchName>-->