### PR TITLE
Remove trailing zeros from Qty, Rate, and Amount fields

### DIFF
--- a/src/components/lcl/EditLCLBOQModal.tsx
+++ b/src/components/lcl/EditLCLBOQModal.tsx
@@ -24,6 +24,7 @@ import { useCurrentCompany } from '@/contexts/CompanyContext';
 import { useCustomers } from '@/hooks/useDatabase';
 import { downloadLCLBOQPDF } from '@/utils/lclBoqPdfGenerator';
 import { LCLHierarchicalData, LCLTemplateStructure } from '@/types/lclTemplate';
+import { formatNumberWithoutTrailingZeros } from '@/utils/numberFormatter';
 
 interface EditLCLBOQModalProps {
   isOpen: boolean;
@@ -461,7 +462,7 @@ export function EditLCLBOQModal({
                     </span>
                   </div>
                   <span className="text-sm font-medium tabular-nums shrink-0">
-                    {sectionTotal.toFixed(2)}
+                    {formatNumberWithoutTrailingZeros(sectionTotal)}
                   </span>
                 </button>
 
@@ -499,9 +500,9 @@ export function EditLCLBOQModal({
                                   <TableCell>
                                     <Input
                                       type="number"
-                                      value={ia.qty.toString()}
+                                      value={formatNumberWithoutTrailingZeros(ia.qty)}
                                       onChange={(e) => handleQtyChange(ia.fullIndex, e.target.value)}
-                                      className="text-sm"
+                                      className="text-sm w-16 md:w-20 lg:w-24"
                                       step="0.01"
                                       min="0"
                                     />
@@ -509,15 +510,15 @@ export function EditLCLBOQModal({
                                   <TableCell>
                                     <Input
                                       type="number"
-                                      value={ia.rate.toString()}
+                                      value={formatNumberWithoutTrailingZeros(ia.rate)}
                                       onChange={(e) => handleRateChange(ia.fullIndex, e.target.value)}
-                                      className="text-sm"
+                                      className="text-sm w-16 md:w-20 lg:w-24"
                                       step="0.01"
                                       min="0"
                                     />
                                   </TableCell>
                                   <TableCell className="text-right font-medium text-sm tabular-nums">
-                                    {ia.amount.toFixed(2)}
+                                    {formatNumberWithoutTrailingZeros(ia.amount)}
                                   </TableCell>
                                 </TableRow>
                               ))}
@@ -526,7 +527,7 @@ export function EditLCLBOQModal({
                                   Subtotal
                                 </TableCell>
                                 <TableCell className="text-right font-medium text-sm tabular-nums">
-                                  {entry.subtotal.toFixed(2)}
+                                  {formatNumberWithoutTrailingZeros(entry.subtotal)}
                                 </TableCell>
                               </TableRow>
                             </TableBody>
@@ -539,7 +540,7 @@ export function EditLCLBOQModal({
                       <div className="text-right">
                         <div className="text-sm text-muted-foreground">Section Total</div>
                         <div className="text-lg font-bold tabular-nums">
-                          {sectionTotal.toFixed(2)}
+                          {formatNumberWithoutTrailingZeros(sectionTotal)}
                         </div>
                       </div>
                     </div>

--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -14,6 +14,7 @@ import { AlertCircle, ChevronRight, Plus, Trash2 } from 'lucide-react';
 import { LCLHierarchicalData, LCLTemplateStructure } from '@/types/lclTemplate';
 import { ConfirmationDialog } from '@/components/ConfirmationDialog';
 import { lclBoqService } from '@/services/lclBoqService';
+import { formatNumberWithoutTrailingZeros } from '@/utils/numberFormatter';
 
 export interface ItemSnapshot {
   section_id: string;
@@ -468,7 +469,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                 </button>
                 <div className="flex items-center gap-3 shrink-0">
                   <span className="text-sm font-medium tabular-nums">
-                    {sectionTotal.toFixed(2)}
+                    {formatNumberWithoutTrailingZeros(sectionTotal)}
                   </span>
                   <Button
                     size="sm"
@@ -521,9 +522,9 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                                 <TableCell>
                                   <Input
                                     type="number"
-                                    value={ia.qty.toString()}
+                                    value={formatNumberWithoutTrailingZeros(ia.qty)}
                                     onChange={(e) => handleQtyChange(ia.fullIndex, e.target.value)}
-                                    className="text-sm h-8"
+                                    className="text-sm h-8 w-16 md:w-20 lg:w-24"
                                     step="0.01"
                                     min="0"
                                   />
@@ -531,15 +532,15 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                                 <TableCell>
                                   <Input
                                     type="number"
-                                    value={ia.rate.toString()}
+                                    value={formatNumberWithoutTrailingZeros(ia.rate)}
                                     onChange={(e) => handleRateChange(ia.fullIndex, e.target.value)}
-                                    className="text-sm h-8"
+                                    className="text-sm h-8 w-16 md:w-20 lg:w-24"
                                     step="0.01"
                                     min="0"
                                   />
                                 </TableCell>
                                 <TableCell className="text-right font-medium text-sm tabular-nums">
-                                  {ia.amount.toFixed(2)}
+                                  {formatNumberWithoutTrailingZeros(ia.amount)}
                                 </TableCell>
                                 <TableCell>
                                   <Button
@@ -577,7 +578,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                                 Subtotal
                               </TableCell>
                               <TableCell className="text-right font-medium text-sm tabular-nums">
-                                {entry.subtotal.toFixed(2)}
+                                {formatNumberWithoutTrailingZeros(entry.subtotal)}
                               </TableCell>
                               <TableCell></TableCell>
                             </TableRow>
@@ -591,7 +592,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                     <div className="text-right">
                       <div className="text-sm text-muted-foreground">Section Total</div>
                       <div className="text-lg font-bold tabular-nums">
-                        {sectionTotal.toFixed(2)}
+                        {formatNumberWithoutTrailingZeros(sectionTotal)}
                       </div>
                     </div>
                   </div>
@@ -671,7 +672,7 @@ function AddItemRow({
         />
       </TableCell>
       <TableCell className="text-right text-sm tabular-nums">
-        {(parseFloat(qty || '0') * parseFloat(rate || '0')).toFixed(2)}
+        {formatNumberWithoutTrailingZeros(parseFloat(qty || '0') * parseFloat(rate || '0'))}
       </TableCell>
       <TableCell>
         <div className="flex gap-1">

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -30,6 +30,7 @@ import {
   loadDraftFromLocalStorage,
   clearDraftFromLocalStorage,
 } from '@/utils/lclTemplateAutosaveUtils';
+import { formatNumberWithoutTrailingZeros } from '@/utils/numberFormatter';
 import { LCLTemplateSaveIndicator } from './LCLTemplateSaveIndicator';
 
 interface LCLTemplateEditorProps {
@@ -75,13 +76,6 @@ export function LCLTemplateEditor({
   const autosaveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const latestInlineEditsRef = useRef<{ [itemId: string]: InlineEdit }>({});
   const { toast } = useToast();
-
-  // Format number to remove unnecessary decimals (1.00 → 1, 1.50 → 1.5)
-  const formatNumber = (value: number): string => {
-    if (typeof value !== 'number') return '0';
-    const formatted = value.toLocaleString('en-KE', { maximumFractionDigits: 2 });
-    return formatted.replace(/\.?0+$/, '');
-  };
 
   // Calculate item amount with inline edits
   const getItemAmount = (item: LCLItemWithCalculations): number => {
@@ -717,7 +711,7 @@ export function LCLTemplateEditor({
           <p className="text-sm font-medium">
             Grand Total (KES):{' '}
             <span className="text-lg font-bold">
-              Ksh{formatNumber(getGrandTotal())}
+              Ksh{formatNumberWithoutTrailingZeros(getGrandTotal())}
             </span>
           </p>
         </div>
@@ -759,7 +753,7 @@ export function LCLTemplateEditor({
                   })()}
                 </div>
                 <p className="text-sm font-medium">
-                  Section Total (KES): Ksh{formatNumber(totals[section.section_id]?.section || 0)}
+                  Section Total (KES): Ksh{formatNumberWithoutTrailingZeros(totals[section.section_id]?.section || 0)}
                 </p>
               </button>
               <Button
@@ -908,7 +902,7 @@ export function LCLTemplateEditor({
                                   {editingItem?.itemId === item.id ? (
                                     <Input
                                       type="number"
-                                      value={editingItem.qty || ''}
+                                      value={formatNumberWithoutTrailingZeros(editingItem.qty || '')}
                                       onChange={(e) =>
                                         setEditingItem({
                                           ...editingItem,
@@ -916,16 +910,16 @@ export function LCLTemplateEditor({
                                         })
                                       }
                                       disabled={loading}
-                                      className="h-7 text-right text-xs md:text-xs px-0.5 py-0 w-full"
+                                      className="h-7 text-right text-xs md:text-xs px-0.5 py-0 w-16 md:w-20 lg:w-24"
                                       step="0.01"
                                     />
                                   ) : (
                                     <Input
                                       type="number"
-                                      value={inlineEdits[item.id]?.qty !== undefined ? inlineEdits[item.id].qty || '' : (item.default_qty || '') }
+                                      value={formatNumberWithoutTrailingZeros(inlineEdits[item.id]?.qty !== undefined ? inlineEdits[item.id].qty || '' : (item.default_qty || ''))}
                                       onChange={(e) => handleInlineQtyChange(item.id, e.target.value)}
                                       disabled={loading}
-                                      className="h-7 text-right text-xs md:text-xs px-0.5 py-0 w-full"
+                                      className="h-7 text-right text-xs md:text-xs px-0.5 py-0 w-16 md:w-20 lg:w-24"
                                       step="0.01"
                                     />
                                   )}
@@ -934,7 +928,7 @@ export function LCLTemplateEditor({
                                   {editingItem?.itemId === item.id ? (
                                     <Input
                                       type="number"
-                                      value={editingItem.rate || ''}
+                                      value={formatNumberWithoutTrailingZeros(editingItem.rate || '')}
                                       onChange={(e) =>
                                         setEditingItem({
                                           ...editingItem,
@@ -942,24 +936,24 @@ export function LCLTemplateEditor({
                                         })
                                       }
                                       disabled={loading}
-                                      className="h-7 text-right text-xs md:text-xs px-0.5 py-0 w-full"
+                                      className="h-7 text-right text-xs md:text-xs px-0.5 py-0 w-16 md:w-20 lg:w-24"
                                       step="0.01"
                                     />
                                   ) : (
                                     <Input
                                       type="number"
-                                      value={inlineEdits[item.id]?.rate !== undefined ? inlineEdits[item.id].rate || '' : (item.default_rate || '')}
+                                      value={formatNumberWithoutTrailingZeros(inlineEdits[item.id]?.rate !== undefined ? inlineEdits[item.id].rate || '' : (item.default_rate || ''))}
                                       onChange={(e) => handleInlineRateChange(item.id, e.target.value)}
                                       disabled={loading}
-                                      className="h-7 text-right text-xs md:text-xs px-0.5 py-0 w-full"
+                                      className="h-7 text-right text-xs md:text-xs px-0.5 py-0 w-16 md:w-20 lg:w-24"
                                       step="0.01"
                                     />
                                   )}
                                 </TableCell>
                                 <TableCell className="text-right text-sm font-semibold">
                                   {editingItem?.itemId === item.id
-                                    ? formatNumber(amount)
-                                    : formatNumber(getItemAmount(item))}
+                                    ? formatNumberWithoutTrailingZeros(amount)
+                                    : formatNumberWithoutTrailingZeros(getItemAmount(item))}
                                 </TableCell>
                                 <TableCell>
                                   {editingItem?.itemId === item.id ? (
@@ -1015,7 +1009,7 @@ export function LCLTemplateEditor({
                             <TableRow className="bg-gray-100 hover:bg-gray-100 cursor-default font-semibold">
                               <TableCell colSpan={5} className="text-sm py-2"></TableCell>
                               <TableCell className="text-right text-sm font-semibold py-2">
-                                Ksh{formatNumber(totals[section.section_id]?.subsections[subsection.subsection_id] || 0)}
+                                Ksh{formatNumberWithoutTrailingZeros(totals[section.section_id]?.subsections[subsection.subsection_id] || 0)}
                               </TableCell>
                               <TableCell></TableCell>
                             </TableRow>
@@ -1067,7 +1061,7 @@ export function LCLTemplateEditor({
                                 <TableCell className="text-right text-sm">
                                   <Input
                                     type="number"
-                                    value={editingItem.qty}
+                                    value={formatNumberWithoutTrailingZeros(editingItem.qty)}
                                     onChange={(e) =>
                                       setEditingItem({
                                         ...editingItem,
@@ -1075,15 +1069,15 @@ export function LCLTemplateEditor({
                                       })
                                     }
                                     disabled={loading}
-                                    className="h-10 text-right text-base md:text-base px-2 py-1"
-                                    placeholder="0.00"
+                                    className="h-10 text-right text-base md:text-base px-2 py-1 w-20 md:w-24 lg:w-32"
+                                    placeholder="0"
                                     step="0.01"
                                   />
                                 </TableCell>
                                 <TableCell className="text-right text-sm">
                                   <Input
                                     type="number"
-                                    value={editingItem.rate}
+                                    value={formatNumberWithoutTrailingZeros(editingItem.rate)}
                                     onChange={(e) =>
                                       setEditingItem({
                                         ...editingItem,
@@ -1091,13 +1085,13 @@ export function LCLTemplateEditor({
                                       })
                                     }
                                     disabled={loading}
-                                    className="h-10 text-right text-base md:text-base px-2 py-1"
-                                    placeholder="0.00"
+                                    className="h-10 text-right text-base md:text-base px-2 py-1 w-20 md:w-24 lg:w-32"
+                                    placeholder="0"
                                     step="0.01"
                                   />
                                 </TableCell>
                                 <TableCell className="text-right text-sm font-semibold">
-                                  {formatNumber(amount)}
+                                  {formatNumberWithoutTrailingZeros(amount)}
                                 </TableCell>
                                 <TableCell>
                                   <div className="flex gap-1">

--- a/src/utils/numberFormatter.ts
+++ b/src/utils/numberFormatter.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats a number to remove trailing zeros and unnecessary decimals
+ * Examples: 10.00 → "10", 10.50 → "10.5", 1500.50 → "1500.5"
+ */
+export const formatNumberWithoutTrailingZeros = (value: number | string | undefined): string => {
+  if (value === undefined || value === null || value === '') return '';
+  
+  const numValue = typeof value === 'string' ? parseFloat(value) : value;
+  
+  if (isNaN(numValue)) return '';
+  
+  // Convert to fixed 2 decimals, then remove trailing zeros
+  const formatted = numValue.toFixed(2);
+  return formatted.replace(/\.?0+$/, '');
+};


### PR DESCRIPTION
### Summary
This PR removes unnecessary trailing zeros (e.g. `10.00 → 10`, `1.50 → 1.5`) from Qty and Rate input fields and Amount/Total display values across the LCL BOQ and template editor components. It also adds responsive width constraints to Qty and Rate inputs.

### Problem
Qty and Rate input fields were displaying values with unnecessary `.00` precision (e.g. `10.00` instead of `10`), and Amount/Total columns similarly showed redundant decimal places, making the UI noisy and harder to read.

### Solution
A shared `formatNumberWithoutTrailingZeros` utility function was introduced and applied consistently across all relevant input fields and display values, replacing both the inline `.toFixed(2)` calls and the local `formatNumber` helper that existed in `LCLTemplateEditor`.

### Key Changes
- **New utility** `src/utils/numberFormatter.ts` — exports `formatNumberWithoutTrailingZeros(value)` which converts a number to at most 2 decimal places and strips trailing zeros
- **`LCLTemplateEditor.tsx`** — removed local `formatNumber` helper; replaced all usages with the shared utility; applied responsive width classes (`w-16 md:w-20 lg:w-24` / `w-20 md:w-24 lg:w-32`) to Qty and Rate inputs; updated placeholders from `"0.00"` to `"0"`
- **`EditLCLBOQModal.tsx`** — replaced `.toFixed(2)` with `formatNumberWithoutTrailingZeros` for Qty/Rate inputs, Amount, Subtotal, and Section Total; added responsive width classes to Qty and Rate inputs
- **`LCLBOQItemEditor.tsx`** — same formatting and responsive width updates as above, including the `AddItemRow` computed amount display


---

<a href="https://builder.io/app/projects/38482bc1b8f249fea9d5/mist-essence-dvj3j4qc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://38482bc1b8f249fea9d5-mist-essence-dvj3j4qc_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=38482bc1b8f249fea9d5&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 289`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>38482bc1b8f249fea9d5</projectId>-->
<!--<branchName>mist-essence-dvj3j4qc</branchName>-->