### PR TITLE
LCL Template: Add formatLCLAmount for amount display

### DIFF
--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -30,7 +30,7 @@ import {
   loadDraftFromLocalStorage,
   clearDraftFromLocalStorage,
 } from '@/utils/lclTemplateAutosaveUtils';
-import { formatNumberWithoutTrailingZeros } from '@/utils/numberFormatter';
+import { formatNumberWithoutTrailingZeros, formatLCLAmount } from '@/utils/numberFormatter';
 import { LCLTemplateSaveIndicator } from './LCLTemplateSaveIndicator';
 
 interface LCLTemplateEditorProps {
@@ -711,7 +711,7 @@ export function LCLTemplateEditor({
           <p className="text-sm font-medium">
             Grand Total (KES):{' '}
             <span className="text-lg font-bold">
-              Ksh{formatNumberWithoutTrailingZeros(getGrandTotal())}
+              Ksh{formatLCLAmount(getGrandTotal())}
             </span>
           </p>
         </div>
@@ -753,7 +753,7 @@ export function LCLTemplateEditor({
                   })()}
                 </div>
                 <p className="text-sm font-medium">
-                  Section Total (KES): Ksh{formatNumberWithoutTrailingZeros(totals[section.section_id]?.section || 0)}
+                  Section Total (KES): Ksh{formatLCLAmount(totals[section.section_id]?.section || 0)}
                 </p>
               </button>
               <Button

--- a/src/utils/numberFormatter.ts
+++ b/src/utils/numberFormatter.ts
@@ -4,12 +4,33 @@
  */
 export const formatNumberWithoutTrailingZeros = (value: number | string | undefined): string => {
   if (value === undefined || value === null || value === '') return '';
-  
+
   const numValue = typeof value === 'string' ? parseFloat(value) : value;
-  
+
   if (isNaN(numValue)) return '';
-  
+
   // Convert to fixed 2 decimals, then remove trailing zeros
   const formatted = numValue.toFixed(2);
   return formatted.replace(/\.?0+$/, '');
+};
+
+/**
+ * Formats a number for LCL amount displays.
+ * If it's an integer (whole number), it displays without decimals (e.g., 7950).
+ * If it has any non-zero decimal part, it keeps exactly 2 decimal places (e.g., 1500.50).
+ */
+export const formatLCLAmount = (value: number | string | undefined): string => {
+  if (value === undefined || value === null || value === '') return '';
+
+  const numValue = typeof value === 'string' ? parseFloat(value) : value;
+
+  if (isNaN(numValue)) return '';
+
+  // If it's a whole number, show it without decimal points
+  if (numValue % 1 === 0) {
+    return numValue.toString();
+  }
+
+  // Otherwise, format with exactly 2 decimal places (e.g., 1500.50)
+  return numValue.toFixed(2);
 };


### PR DESCRIPTION
### Summary
Introduces a new `formatLCLAmount` utility and applies it to grand total and section total displays in the LCL Template Editor, removing unnecessary `.00` from whole-number amounts while preserving two decimal places for fractional values.

### Problem
Amount columns in the LCL template were displaying whole numbers with unnecessary `.00` precision (e.g., `7950.00` instead of `7950`), while values like `1500.50` should retain their decimal places. The existing `formatNumberWithoutTrailingZeros` utility strips all trailing zeros, which would render `1500.50` as `1500.5` — not the desired two-decimal behavior for currency amounts.

### Solution
A dedicated `formatLCLAmount` function was added to the `numberFormatter` utility. It checks whether a number is a whole integer and, if so, displays it without decimals; otherwise it formats to exactly two decimal places. This function is then used in place of `formatNumberWithoutTrailingZeros` for the grand total and section total displays in `LCLTemplateEditor`.

### Key Changes
- **`src/utils/numberFormatter.ts`**: Added `formatLCLAmount` export — displays whole numbers without decimals (e.g., `7950`) and fractional numbers with exactly 2 decimal places (e.g., `1500.50`).
- **`src/components/lclTemplate/LCLTemplateEditor.tsx`**: Imported `formatLCLAmount` and applied it to:
  - Grand Total (KES) display
  - Section Total (KES) display


---

<a href="https://builder.io/app/projects/73f0cf9f125547f9b9fe/warlock-frigate-wpxz513m"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://73f0cf9f125547f9b9fe-warlock-frigate-wpxz513m_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=73f0cf9f125547f9b9fe&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 290`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>73f0cf9f125547f9b9fe</projectId>-->
<!--<branchName>warlock-frigate-wpxz513m</branchName>-->