### PR TITLE
Fix LCL BOQ item drag-and-drop reordering

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -74,6 +74,8 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
   const [draftPending, setDraftPending] = useState(false);
   const [addItemForm, setAddItemForm] = useState<AddItemForm | null>(null);
   const [removeConfirm, setRemoveConfirm] = useState<{ type: 'section' | 'item'; id: string; label: string } | null>(null);
+  const [draggedItemIndex, setDraggedItemIndex] = useState<number | null>(null);
+  const [dragOverItemIndex, setDragOverItemIndex] = useState<number | null>(null);
   const inlineEditsRef = useRef<{ [itemId: string]: InlineEdit }>({});
   const autosaveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const { toast } = useToast();
@@ -318,6 +320,104 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     setRemoveConfirm(null);
   };
 
+  const handleDragStart = (e: React.DragEvent<HTMLTableRowElement>, itemIndex: number) => {
+    setDraggedItemIndex(itemIndex);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLTableRowElement>, itemIndex: number) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverItemIndex(itemIndex);
+  };
+
+  const handleDragLeave = () => {
+    setDragOverItemIndex(null);
+  };
+
+  const handleDrop = (
+    e: React.DragEvent<HTMLTableRowElement>,
+    targetIndex: number,
+    subsectionItems: ItemSnapshot[],
+    sectionId: string,
+    subsectionId: string
+  ) => {
+    e.preventDefault();
+
+    if (draggedItemIndex === null) return;
+
+    const draggedItem = items[draggedItemIndex];
+
+    // Only allow drops within the same subsection
+    if (draggedItem.subsection_id !== subsectionId) {
+      setDraggedItemIndex(null);
+      setDragOverItemIndex(null);
+      return;
+    }
+
+    // Find indices within the subsection
+    const draggedIdxInSubsection = subsectionItems.findIndex((item) => item === draggedItem);
+    const targetIdxInSubsection = subsectionItems.findIndex((item) => item === items[targetIndex]);
+
+    if (draggedIdxInSubsection === targetIdxInSubsection) {
+      setDraggedItemIndex(null);
+      setDragOverItemIndex(null);
+      return;
+    }
+
+    // Reorder subsection items
+    const reordered = [...subsectionItems];
+    reordered.splice(draggedIdxInSubsection, 1);
+    reordered.splice(targetIdxInSubsection, 0, draggedItem);
+
+    // Renumber items in the subsection
+    const renumbered = reordered.map((item, idx) => ({
+      ...item,
+      item_number: String(idx + 1),
+    }));
+
+    // Rebuild full items array with reordered subsection
+    const newItems = items.map((item) => {
+      if (item.section_id === sectionId && item.subsection_id === subsectionId) {
+        const found = renumbered.find((r) => r.description === item.description && r.unit === item.unit && r.qty === item.qty && r.rate === item.rate);
+        return found || item;
+      }
+      return item;
+    });
+
+    setItems(newItems);
+    setDraftPending(true);
+    setDraggedItemIndex(null);
+    setDragOverItemIndex(null);
+
+    // Persist to database immediately if companyId is provided
+    if (companyId) {
+      (async () => {
+        try {
+          await lclBoqService.autosaveLCLBOQDraftWithUpsert({
+            company_id: companyId,
+            number: 'DRAFT',
+            items_snapshot: newItems,
+            status: 'draft',
+          });
+          toast({ title: 'Success', description: 'Item reordered and saved.' });
+        } catch (error) {
+          console.error('Failed to persist reorder:', error);
+          toast({
+            title: 'Warning',
+            description: 'Item reordered locally but failed to save to database.',
+            variant: 'destructive',
+          });
+        }
+      })();
+    }
+  };
+
+  const handleDragEnd = () => {
+    setDraggedItemIndex(null);
+    setDragOverItemIndex(null);
+  };
+
   const handleAddItem = (subsectionId: string, sectionLetter: string) => {
     setAddItemForm({ subsectionId, sectionLetter });
     setDraftPending(true);
@@ -505,7 +605,20 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                           </TableHeader>
                           <TableBody>
                             {entry.itemsWithAmount.map((ia, idx) => (
-                              <TableRow key={idx}>
+                              <TableRow
+                                key={idx}
+                                draggable
+                                onDragStart={(e) => handleDragStart(e, ia.fullIndex)}
+                                onDragOver={(e) => handleDragOver(e, ia.fullIndex)}
+                                onDragLeave={handleDragLeave}
+                                onDrop={(e) => handleDrop(e, ia.fullIndex, entry.itemsWithAmount.map((x) => x.item), sectionId, entry.subsectionId)}
+                                onDragEnd={handleDragEnd}
+                                className={`
+                                  cursor-grab active:cursor-grabbing
+                                  ${draggedItemIndex === ia.fullIndex ? 'opacity-50 bg-muted' : ''}
+                                  ${dragOverItemIndex === ia.fullIndex ? 'border-t-2 border-blue-500' : ''}
+                                `}
+                              >
                                 <TableCell className="text-xs text-muted-foreground">
                                   {ia.item.item_number}
                                 </TableCell>

--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -360,8 +360,8 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     if (companyId) {
       try {
         const updatedItems = [...items, newItem];
-        // Save draft BOQ with updated items
-        await lclBoqService.autosaveLCLBOQDraft({
+        // Save draft BOQ with updated items using upsert to maintain single draft per company
+        await lclBoqService.autosaveLCLBOQDraftWithUpsert({
           company_id: companyId,
           number: 'DRAFT',
           items_snapshot: updatedItems,

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -795,7 +795,7 @@ export function LCLTemplateEditor({
                         </p>
                       </div>
                       <p className="text-sm">
-                        Subtotal (KES): Ksh{formatNumber(totals[section.section_id]?.subsections[subsection.subsection_id] || 0)}
+                        Subtotal (KES): Ksh{formatLCLAmount(totals[section.section_id]?.subsections[subsection.subsection_id] || 0)}
                       </p>
                     </button>
 

--- a/src/services/lclBoqService.ts
+++ b/src/services/lclBoqService.ts
@@ -122,6 +122,35 @@ class LCLBOQService {
   }
 
   /**
+   * Auto-save draft with upsert logic
+   * Maintains a single draft per company by checking for existing draft and updating it
+   * rather than creating a new one, avoiding UNIQUE constraint violations
+   */
+  async autosaveLCLBOQDraftWithUpsert(boq: LCLBOQRecord): Promise<LCLBOQRecord> {
+    // Query for existing draft with number='DRAFT' for this company
+    const { data: existingDraft } = await supabase
+      .from('lcl_boqs')
+      .select('id')
+      .eq('company_id', boq.company_id)
+      .eq('number', 'DRAFT')
+      .single();
+
+    // If draft exists, update it; otherwise create new one
+    if (existingDraft) {
+      return this.saveLCLBOQ({
+        ...boq,
+        id: existingDraft.id,
+        status: 'draft',
+      });
+    } else {
+      return this.saveLCLBOQ({
+        ...boq,
+        status: 'draft',
+      });
+    }
+  }
+
+  /**
    * Save final version (update status to 'saved')
    */
   async saveLCLBOQFinal(boq: LCLBOQRecord): Promise<LCLBOQRecord> {


### PR DESCRIPTION
### Summary
Fixes drag-and-drop reordering of items in the LCL BOQ editor so that reordering actually takes effect and persists to the database. Also introduces an upsert-based draft save to prevent duplicate draft records per company.

### Problem
The LCL template's drag-and-drop feature reported success but did not visually reorder items or persist the new order. Additionally, saving a draft could create duplicate records due to a UNIQUE constraint on the draft number per company.

### Solution
Implemented proper HTML5 drag event handlers (`onDragStart`, `onDragOver`, `onDragLeave`, `onDrop`, `onDragEnd`) on table rows, with state tracking for the dragged and drag-over indices. A new `autosaveLCLBOQDraftWithUpsert` service method checks for an existing draft before saving, updating it in place rather than inserting a new record.

### Key Changes
- **`LCLBOQItemEditor.tsx`**: Added `draggedItemIndex` and `dragOverItemIndex` state; implemented `handleDragStart`, `handleDragOver`, `handleDragLeave`, `handleDrop`, and `handleDragEnd` handlers; applied drag event props and visual feedback classes (`opacity-50`, `border-t-2 border-blue-500`, `cursor-grab`) to `TableRow` elements; switched `handleAddItem` to use `autosaveLCLBOQDraftWithUpsert`.
- **`lclBoqService.ts`**: Added `autosaveLCLBOQDraftWithUpsert` method that queries for an existing `DRAFT` record per company and updates it if found, or creates a new one — preventing UNIQUE constraint violations.
- **`LCLTemplateEditor.tsx`**: Fixed subsection subtotal display to use `formatLCLAmount` instead of `formatNumber` for correct formatting.


---

<a href="https://builder.io/app/projects/59c7800e6d7640579ba3/plateau-trace-wc176qwr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://59c7800e6d7640579ba3-plateau-trace-wc176qwr_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=59c7800e6d7640579ba3&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 291`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>59c7800e6d7640579ba3</projectId>-->
<!--<branchName>plateau-trace-wc176qwr</branchName>-->