### PR TITLE
Fix LCL template item drag-and-drop reordering

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -361,11 +361,13 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
       return;
     }
 
-    // Find indices within the subsection by id
-    const draggedIdxInSubsection = subsectionItems.findIndex((item) => item.id === draggedItem.id);
-    const targetIdxInSubsection = subsectionItems.findIndex((item) => item.id === items[targetIndex].id);
+    // Use positional matching instead of ID-based matching
+    // This works for items with or without IDs
+    const draggedIdxInSubsection = subsectionItems.findIndex((item) => item === draggedItem);
+    const targetItemInSubsection = items[targetIndex];
+    const targetIdxInSubsection = subsectionItems.findIndex((item) => item === targetItemInSubsection);
 
-    if (draggedIdxInSubsection === targetIdxInSubsection) {
+    if (draggedIdxInSubsection === -1 || targetIdxInSubsection === -1 || draggedIdxInSubsection === targetIdxInSubsection) {
       setDraggedItemIndex(null);
       setDragOverItemIndex(null);
       return;
@@ -385,7 +387,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     // Rebuild full items array with reordered subsection
     const newItems = items.map((item) => {
       if (item.section_id === sectionId && item.subsection_id === subsectionId) {
-        const found = renumbered.find((r) => r.id === item.id);
+        const found = renumbered.find((r) => r === item);
         return found || item;
       }
       return item;
@@ -449,6 +451,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     }, 0);
 
     const newItem: ItemSnapshot = {
+      id: crypto.randomUUID(),
       section_id: section.section_id,
       section_name: section.section_name,
       subsection_id: subsection.subsection_id,

--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -14,9 +14,11 @@ import { AlertCircle, ChevronRight, Plus, Trash2 } from 'lucide-react';
 import { LCLHierarchicalData, LCLTemplateStructure } from '@/types/lclTemplate';
 import { ConfirmationDialog } from '@/components/ConfirmationDialog';
 import { lclBoqService } from '@/services/lclBoqService';
+import { lclTemplateService } from '@/services/lclTemplateService';
 import { formatNumberWithoutTrailingZeros } from '@/utils/numberFormatter';
 
 export interface ItemSnapshot {
+  id?: string;
   section_id: string;
   section_name?: string;
   subsection_id: string;
@@ -50,6 +52,7 @@ interface LCLBOQItemEditorProps {
   templateStructure?: LCLTemplateStructure;
   companyId?: string;
   initialItems?: ItemSnapshot[];
+  structureId?: string;
 }
 
 const getDraftKey = (structureId: string) => `lcl_boq_creation_draft_${structureId}`;
@@ -65,6 +68,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
   templateStructure,
   companyId,
   initialItems,
+  structureId,
 }: LCLBOQItemEditorProps, ref) {
   const [items, setItems] = useState<ItemSnapshot[]>([]);
   const [inlineEdits, setInlineEdits] = useState<{ [itemId: string]: InlineEdit }>({});
@@ -119,6 +123,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
       section.subsections.forEach((subsection) => {
         subsection.items.forEach((item: any) => {
           snapshot.push({
+            id: item.id,
             section_id: section.section_id,
             section_name: section.section_name,
             subsection_id: subsection.subsection_id,
@@ -340,7 +345,8 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     targetIndex: number,
     subsectionItems: ItemSnapshot[],
     sectionId: string,
-    subsectionId: string
+    subsectionId: string,
+    structureId: string
   ) => {
     e.preventDefault();
 
@@ -355,9 +361,9 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
       return;
     }
 
-    // Find indices within the subsection
-    const draggedIdxInSubsection = subsectionItems.findIndex((item) => item === draggedItem);
-    const targetIdxInSubsection = subsectionItems.findIndex((item) => item === items[targetIndex]);
+    // Find indices within the subsection by id
+    const draggedIdxInSubsection = subsectionItems.findIndex((item) => item.id === draggedItem.id);
+    const targetIdxInSubsection = subsectionItems.findIndex((item) => item.id === items[targetIndex].id);
 
     if (draggedIdxInSubsection === targetIdxInSubsection) {
       setDraggedItemIndex(null);
@@ -379,7 +385,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     // Rebuild full items array with reordered subsection
     const newItems = items.map((item) => {
       if (item.section_id === sectionId && item.subsection_id === subsectionId) {
-        const found = renumbered.find((r) => r.description === item.description && r.unit === item.unit && r.qty === item.qty && r.rate === item.rate);
+        const found = renumbered.find((r) => r.id === item.id);
         return found || item;
       }
       return item;
@@ -390,27 +396,29 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     setDraggedItemIndex(null);
     setDragOverItemIndex(null);
 
-    // Persist to database immediately if companyId is provided
-    if (companyId) {
-      (async () => {
-        try {
-          await lclBoqService.autosaveLCLBOQDraftWithUpsert({
-            company_id: companyId,
-            number: 'DRAFT',
-            items_snapshot: newItems,
-            status: 'draft',
-          });
-          toast({ title: 'Success', description: 'Item reordered and saved.' });
-        } catch (error) {
-          console.error('Failed to persist reorder:', error);
-          toast({
-            title: 'Warning',
-            description: 'Item reordered locally but failed to save to database.',
-            variant: 'destructive',
-          });
-        }
-      })();
-    }
+    // Persist to database immediately
+    (async () => {
+      try {
+        const updatedItemIds = renumbered.map((item) => item.id).filter((id): id is string => !!id);
+        const newSortOrders = renumbered.map((_, idx) => idx);
+
+        await lclTemplateService.updateItemsSortOrder(
+          structureId,
+          sectionId,
+          subsectionId,
+          updatedItemIds,
+          newSortOrders
+        );
+        toast({ title: 'Success', description: 'Item reordered and saved.' });
+      } catch (error) {
+        console.error('Failed to persist reorder:', error);
+        toast({
+          title: 'Warning',
+          description: 'Item reordered locally but failed to save to database.',
+          variant: 'destructive',
+        });
+      }
+    })();
   };
 
   const handleDragEnd = () => {
@@ -611,7 +619,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                                 onDragStart={(e) => handleDragStart(e, ia.fullIndex)}
                                 onDragOver={(e) => handleDragOver(e, ia.fullIndex)}
                                 onDragLeave={handleDragLeave}
-                                onDrop={(e) => handleDrop(e, ia.fullIndex, entry.itemsWithAmount.map((x) => x.item), sectionId, entry.subsectionId)}
+                                onDrop={(e) => handleDrop(e, ia.fullIndex, entry.itemsWithAmount.map((x) => x.item), sectionId, entry.subsectionId, structureId || '')}
                                 onDragEnd={handleDragEnd}
                                 className={`
                                   cursor-grab active:cursor-grabbing

--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -42,6 +42,7 @@ export default function LCLTemplate() {
   const headerAutosaveRef = useRef<NodeJS.Timeout | null>(null);
 
   const [initialItems, setInitialItems] = useState<ItemSnapshot[]>([]);
+  const [structureId, setStructureId] = useState<string>('');
 
   const loadLCLBOQData = async () => {
     if (!companyId) return;
@@ -69,6 +70,7 @@ export default function LCLTemplate() {
       const data =
         await lclTemplateService.getHierarchicalData(lclDefaultStructure.id);
       setHierarchicalData(data);
+      setStructureId(lclDefaultStructure.id);
 
       // Load previously-added items from the most recent BOQ (saved or draft)
       try {
@@ -426,6 +428,7 @@ export default function LCLTemplate() {
         templateStructure={undefined}
         companyId={companyId}
         initialItems={initialItems}
+        structureId={structureId}
       />
     </div>
   );

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -167,9 +167,15 @@ export class LCLTemplateService {
   ): Promise<LCLTemplateItem[]> {
     const updatedItems: LCLTemplateItem[] = [];
 
+    // Only update items that have valid IDs (skip items with missing IDs)
     for (let index = 0; index < itemIds.length; index++) {
       const itemId = itemIds[index];
       const sortOrder = sortOrders[index];
+
+      // Skip empty IDs (items created locally without DB entry)
+      if (!itemId) {
+        continue;
+      }
 
       const updated = await this.updateItem(itemId, {
         sort_order: sortOrder,

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -158,6 +158,29 @@ export class LCLTemplateService {
     return updatedItems;
   }
 
+  async updateItemsSortOrder(
+    structureId: string,
+    sectionId: string,
+    subsectionId: string,
+    itemIds: string[],
+    sortOrders: number[]
+  ): Promise<LCLTemplateItem[]> {
+    const updatedItems: LCLTemplateItem[] = [];
+
+    for (let index = 0; index < itemIds.length; index++) {
+      const itemId = itemIds[index];
+      const sortOrder = sortOrders[index];
+
+      const updated = await this.updateItem(itemId, {
+        sort_order: sortOrder,
+        item_number: String(index + 1),
+      });
+      updatedItems.push(updated);
+    }
+
+    return updatedItems;
+  }
+
   async getHierarchicalData(
     structureId: string
   ): Promise<LCLHierarchicalData> {


### PR DESCRIPTION
### Summary
Fixes the drag-and-drop reordering of items within LCL template sections, which previously appeared to succeed but did not actually persist or visually reorder items correctly.

### Problem
Dragging items within a subsection in the LCL template showed a success toast but the items did not reorder. The drop handler used unreliable field-value matching to find items in the list, and the persistence logic wrote to the BOQ draft instead of updating the template item sort order in the database.

### Solution
Replaced field-value-based item matching with reference-based (identity) matching so items are correctly located during a drop. Introduced a dedicated `updateItemsSortOrder` method in `lclTemplateService` that updates each item's `sort_order` and `item_number` directly in the database. The `structureId` is now threaded from `LCLTemplate` down to the drop handler so the correct template structure is targeted.

### Key Changes
- **`LCLBOQItemEditor.tsx`**: 
  - Added `structureId` prop and passed it through to `handleDrop`.
  - Switched item lookup in `handleDrop` from field-value comparison to object reference equality (`item === ...`), fixing incorrect index resolution.
  - Added guard for `-1` indices to prevent no-op drops from proceeding.
  - Replaced BOQ draft autosave on reorder with a call to `lclTemplateService.updateItemsSortOrder`.
  - Added `id` field to `ItemSnapshot` interface and populated it when building snapshots and creating new items (`crypto.randomUUID()`).
- **`lclTemplateService.ts`**: Added `updateItemsSortOrder` method that iterates over reordered item IDs and updates `sort_order` and `item_number` for each via `updateItem`, skipping items without a database ID.
- **`LCLTemplate.tsx`**: Tracks and passes `structureId` state to `LCLBOQItemEditor` after loading the default LCL structure.


---

<a href="https://builder.io/app/projects/db35b9f51ca743e2b603/dim-button-tbnd8eyz"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://db35b9f51ca743e2b603-dim-button-tbnd8eyz_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=db35b9f51ca743e2b603&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 292`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>db35b9f51ca743e2b603</projectId>-->
<!--<branchName>dim-button-tbnd8eyz</branchName>-->