### PR TITLE
Add editable section titles in LCL BOQ editor

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -16,7 +16,7 @@ import { ConfirmationDialog } from '@/components/ConfirmationDialog';
 import { lclBoqService } from '@/services/lclBoqService';
 import { lclTemplateService } from '@/services/lclTemplateService';
 import { formatNumberWithoutTrailingZeros } from '@/utils/numberFormatter';
-import { getDisplaySectionName } from '@/utils/lclSectionDisplayUtils';
+import { getDisplaySectionName, buildSectionDisplayHeader } from '@/utils/lclSectionDisplayUtils';
 
 export interface ItemSnapshot {
   id?: string;
@@ -81,6 +81,8 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
   const [removeConfirm, setRemoveConfirm] = useState<{ type: 'section' | 'item'; id: string; label: string } | null>(null);
   const [draggedItemIndex, setDraggedItemIndex] = useState<number | null>(null);
   const [dragOverItemIndex, setDragOverItemIndex] = useState<number | null>(null);
+  const [editingSectionLetter, setEditingSectionLetter] = useState<string | null>(null);
+  const [editingSectionName, setEditingSectionName] = useState<string>('');
   const inlineEditsRef = useRef<{ [itemId: string]: InlineEdit }>({});
   const autosaveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const { toast } = useToast();
@@ -443,6 +445,39 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     setDragOverItemIndex(null);
   };
 
+  const handleEditSectionTitle = (sectionLetter: string, currentName: string) => {
+    setEditingSectionLetter(sectionLetter);
+    setEditingSectionName(getDisplaySectionName(currentName));
+  };
+
+  const handleSaveSectionTitle = (sectionLetter: string) => {
+    if (!editingSectionName.trim()) {
+      return;
+    }
+
+    setItems((prev) => {
+      const updatedItems = prev.map((item) => {
+        if (getSectionLetter(item.section_id) === sectionLetter) {
+          return {
+            ...item,
+            section_name: buildSectionDisplayHeader(sectionLetter, editingSectionName),
+          };
+        }
+        return item;
+      });
+      return updatedItems;
+    });
+
+    setDraftPending(true);
+    setEditingSectionLetter(null);
+    setEditingSectionName('');
+  };
+
+  const handleCancelEditSection = () => {
+    setEditingSectionLetter(null);
+    setEditingSectionName('');
+  };
+
   const handleAddItem = (subsectionId: string, sectionLetter: string) => {
     setAddItemForm({ subsectionId, sectionLetter });
     setDraftPending(true);
@@ -589,9 +624,33 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
                   <ChevronRight
                     className={`h-4 w-4 shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
                   />
-                  <span className="font-semibold text-sm truncate">
-                    SECTION {sectionLetter}: {getDisplaySectionName(sectionName)}
-                  </span>
+                  {editingSectionLetter === sectionLetter ? (
+                    <Input
+                      value={editingSectionName}
+                      onChange={(e) => setEditingSectionName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          handleSaveSectionTitle(sectionLetter);
+                        } else if (e.key === 'Escape') {
+                          handleCancelEditSection();
+                        }
+                      }}
+                      className="h-7 font-semibold text-sm flex-1"
+                      autoFocus
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  ) : (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEditSectionTitle(sectionLetter, sectionName);
+                      }}
+                      className="font-semibold text-sm hover:bg-muted px-2 py-1 rounded transition-colors truncate"
+                      title="Click to edit section title"
+                    >
+                      SECTION {sectionLetter}: {getDisplaySectionName(sectionName)}
+                    </button>
+                  )}
                 </button>
                 <div className="flex items-center gap-3 shrink-0">
                   <span className="text-sm font-medium tabular-nums">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -114,7 +114,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   // Fetch user profile from database with error handling and retry logic
   const fetchProfile = useCallback(async (userId: string, showErrorToast: boolean = false): Promise<UserProfile | null> => {
-    const maxRetries = 3;
+    const maxRetries = 2;
     let lastError: any = null;
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -153,8 +153,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                               errorMsg.includes('fetch');
 
         if (isNetworkError && attempt < maxRetries - 1) {
-          // Wait before retrying (exponential backoff: 500ms, 1s, 2s)
-          const delayMs = 500 * Math.pow(2, attempt);
+          // Wait before retrying (exponential backoff: 300ms, 600ms)
+          const delayMs = 300 * Math.pow(2, attempt);
           console.warn(`Profile fetch network error (attempt ${attempt + 1}/${maxRetries}). Retrying in ${delayMs}ms... Error: ${errorMsg}`);
           await new Promise(resolve => setTimeout(resolve, delayMs));
           continue;
@@ -309,11 +309,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       }
     };
 
-    // CRITICAL: Ensure initialization completes within 3 seconds no matter what
+    // CRITICAL: Ensure initialization completes within 2 seconds no matter what
     const hardTimeout = setTimeout(() => {
       console.warn('⚠️ Hard timeout: completing initialization');
       completeInit();
-    }, 3000);
+    }, 2000);
 
     const initializeAuthState = async () => {
       try {
@@ -321,7 +321,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
         // Simple session check with timeout
         const sessionTimeoutPromise = new Promise((_, reject) => {
-          setTimeout(() => reject(new Error('Session check timeout')), 1500);
+          setTimeout(() => reject(new Error('Session check timeout')), 800);
         });
 
         try {
@@ -338,9 +338,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             // Fetch profile in background with timeout
             const profileTimeoutPromise = new Promise<UserProfile | null>((resolve) => {
               setTimeout(() => {
-                console.warn('⏱️ Profile fetch timeout (5s)');
+                console.warn('⏱️ Profile fetch timeout (1.5s)');
                 resolve(null);
-              }, 5000);
+              }, 1500);
             });
 
             Promise.race([
@@ -437,12 +437,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           // This ensures components render with correct role/email filtering
           const profileTimeoutPromise = new Promise<UserProfile | null>((resolve) => {
             setTimeout(() => {
-              console.warn('⏱️ Profile fetch timeout during sign in (5s)');
+              console.warn('⏱️ Profile fetch timeout during sign in (2s)');
               resolve(null);
-            }, 5000); // 5 second timeout for sign in flow
+            }, 2000); // 2 second timeout for sign in flow
           });
 
-          console.log('🔍 Starting profile fetch with 5s timeout...');
+          console.log('🔍 Starting profile fetch with 2s timeout...');
           const userProfile = await Promise.race([
             fetchProfile(signedInUser.id),
             profileTimeoutPromise
@@ -480,7 +480,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 setTimeout(() => {
                   console.warn('⏱️ Profile retry timeout');
                   resolve(null);
-                }, 10000); // 10 second timeout for background retry
+                }, 5000); // 5 second timeout for background retry
               });
 
               Promise.race([


### PR DESCRIPTION
### Summary
Adds click-to-edit inline section title functionality to the LCL BOQ Item Editor, allowing users to rename section headers during BOQ creation without affecting the global template. Also reduces auth initialization timeouts to speed up login.

### Problem
Section titles in the BOQ creation flow (`LCLBOQItemEditor.tsx`) were read-only. Users had no way to customize section names (e.g., "SECTION A: Foundation") for a specific BOQ instance without modifying the underlying template. Additionally, login was slow due to overly generous auth timeout values.

### Solution
Implemented a click-to-edit inline pattern for section titles in `LCLBOQItemEditor.tsx`, consistent with the existing pattern in the template editor. When a user clicks a section title, it becomes an input field; pressing Enter saves the change and pressing Escape cancels it. Changes are propagated to all items in the section via `section_name` and persisted through the existing draft/autosave mechanism. Auth timeouts were also tightened to reduce perceived login latency.

### Key Changes
- **New state**: Added `editingSectionLetter` and `editingSectionName` state to `LCLBOQItemEditor` to track which section is being edited and its current input value.
- **New handlers**:
  - `handleEditSectionTitle` — enters edit mode for a section, pre-populating the input with the current display name.
  - `handleSaveSectionTitle` — updates all items in the section with the new `section_name` (built via `buildSectionDisplayHeader`), marks the draft as pending, and exits edit mode.
  - `handleCancelEditSection` — exits edit mode without saving.
- **Updated section header rendering**: Replaced the static `<span>` with a conditional render — an `<Input>` when editing, or a clickable `<button>` when not editing, with a hover style and tooltip.
- **Imported `buildSectionDisplayHeader`** from `lclSectionDisplayUtils` to construct the updated section name string.
- **Auth timeout reductions** (`AuthContext.tsx`): Reduced max retries from 3→2, hard init timeout from 3s→2s, session check timeout from 1.5s→800ms, profile fetch timeouts from 5s→1.5s (init) and 5s→2s (sign-in), and background retry timeout from 10s→5s.


---

<a href="https://builder.io/app/projects/c04ba146988f4d309111/swift-capsule-jfdgmrqc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://c04ba146988f4d309111-swift-capsule-jfdgmrqc_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=c04ba146988f4d309111&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 296`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c04ba146988f4d309111</projectId>-->
<!--<branchName>swift-capsule-jfdgmrqc</branchName>-->