### PR TITLE
Fix LCL template section auto-renumbering on delete

### DIFF
--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -586,7 +586,7 @@ export function LCLTemplateEditor({
   };
 
   const handleDeleteSection = async (sectionId: string, sectionName: string) => {
-    if (!window.confirm(`Remove "${sectionName}" from this BOQ? The template remains unchanged.`)) return;
+    if (!window.confirm(`Remove "${sectionName}" from this template? All items in this section will be deleted.`)) return;
 
     setLoading(true);
     try {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -304,6 +304,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const completeInit = () => {
       if (!completed && mountedRef.current) {
         completed = true;
+        initializingRef.current = false;
         setLoading(false);
         setInitialized(true);
       }
@@ -399,6 +400,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, [fetchProfile, handleAuthStateChange]);
 
   const signIn = useCallback(async (email: string, password: string) => {
+    const hardTimeoutId = setTimeout(() => {
+      console.warn('⚠️ Sign-in hard timeout (3s): forcing loading state clear');
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }, 3000);
+
     const { data, error } = await safeAuthOperation(async () => {
       setLoading(true);
       return await supabase.auth.signInWithPassword({
@@ -408,6 +416,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }, 'signIn');
 
     if (error) {
+      clearTimeout(hardTimeoutId);
       setLoading(false);
       // Ensure error is a proper Error object with a message property
       const errorMessage = parseErrorMessage(error);
@@ -416,6 +425,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
 
     if (data?.error) {
+      clearTimeout(hardTimeoutId);
       setLoading(false);
       // Ensure error is a proper Error object with a message property
       const errorMessage = parseErrorMessage(data.error);
@@ -527,6 +537,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       });
       setLoading(false);
     }
+    clearTimeout(hardTimeoutId);
     setTimeout(() => toast.success('Signed in successfully'), 0);
     return { error: null };
   }, [fetchProfile]);

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -286,43 +286,80 @@ export class LCLTemplateService {
     const structure = await this.getStructure(structureId);
     const sections = structure.structure_data.sections;
 
-    // Find index of deleted section
-    const deletedIndex = sections.findIndex((s: any) => s.id === deletedSectionId);
-    if (deletedIndex === -1) {
+    // Remove the deleted section from array
+    const remainingSections = sections.filter(
+      (s: any) => s.id !== deletedSectionId
+    );
+
+    if (remainingSections.length === sections.length) {
       return structure;
     }
 
-    // Map old letter to new letter for sections after the deleted one
-    const letterMap = new Map<string, string>();
-    let newLetter = String.fromCharCode(65 + deletedIndex);
+    // Create mapping of old section IDs to new section IDs with consecutive letters
+    const sectionIdMap = new Map<string, string>();
+    const updatedSections = remainingSections.map((section: any, index: number) => {
+      const newLetter = String.fromCharCode(65 + index);
+      const oldId = section.id;
+      const newId = `section_${newLetter.toLowerCase()}`;
 
-    for (let i = deletedIndex + 1; i < sections.length; i++) {
-      const section = sections[i];
-      const oldLetter = String.fromCharCode(65 + i);
-      letterMap.set(oldLetter, newLetter);
-      newLetter = String.fromCharCode(newLetter.charCodeAt(0) + 1);
-    }
+      sectionIdMap.set(oldId, newId);
 
-    // Renumber display names for affected sections
-    const updatedSections = sections.map((section: any, index: number) => {
-      if (index <= deletedIndex) return section;
+      // Extract custom name and update with new letter
+      const nameMatch = section.name.match(/^(?:SECTION|Section)\s+[A-Z]:\s*(.+)$/);
+      const customName = nameMatch ? nameMatch[1] : section.name;
 
-      const currentLetter = String.fromCharCode(65 + index);
-      const newLetter = letterMap.get(currentLetter);
+      // Also rebuild subsection IDs to match the new section ID
+      const updatedSubsections = section.subsections.map(
+        (subsection: any) => {
+          const oldSubsectionId = subsection.id;
+          // Subsection IDs follow pattern: section_X_X_name, where X is the letter
+          // Replace both occurrences: section_d_d_name -> section_c_c_name
+          const oldLetter = oldId.match(/section_([a-z])/)?.[1] || '';
+          const newLetter = newId.match(/section_([a-z])/)?.[1] || '';
+          const newSubsectionId = oldSubsectionId.replace(
+            new RegExp(oldLetter, 'g'),
+            newLetter
+          );
+          sectionIdMap.set(oldSubsectionId, newSubsectionId);
+          return {
+            ...subsection,
+            id: newSubsectionId,
+          };
+        }
+      );
 
-      if (newLetter && newLetter !== currentLetter) {
-        // Extract custom name (everything after colon)
-        const nameMatch = section.name.match(/^(?:SECTION|Section)\s+[A-Z]:\s*(.+)$/);
-        const customName = nameMatch ? nameMatch[1] : section.name;
-
-        return {
-          ...section,
-          name: `SECTION ${newLetter}: ${customName}`,
-        };
-      }
-
-      return section;
+      return {
+        ...section,
+        id: newId,
+        name: `SECTION ${newLetter}: ${customName}`,
+        subsections: updatedSubsections,
+      };
     });
+
+    // Update all item references to use new section and subsection IDs
+    const items = await this.getStructureItems(structureId);
+    for (const item of items) {
+      const newSectionId = sectionIdMap.get(item.section_id);
+      const newSubsectionId = sectionIdMap.get(item.subsection_id);
+
+      if (newSectionId && newSubsectionId) {
+        await this.updateItem(item.id, {
+          section_id: newSectionId,
+          subsection_id: newSubsectionId,
+        });
+      } else if (newSectionId && !newSubsectionId) {
+        // If subsection ID mapping not found but section ID is found, rebuild it with new letter
+        const oldLetter = item.section_id.match(/section_([a-z])/)?.[1] || '';
+        const newLetterFromId = newSectionId.match(/section_([a-z])/)?.[1] || '';
+        const newSubId = item.subsection_id
+          .replace(item.section_id, newSectionId)
+          .replace(new RegExp(oldLetter, 'g'), newLetterFromId);
+        await this.updateItem(item.id, {
+          section_id: newSectionId,
+          subsection_id: newSubId,
+        });
+      }
+    }
 
     // Persist updated sections
     await this.updateStructure(structureId, {


### PR DESCRIPTION
### Summary
Fixes LCL template section renumbering so that when a section is deleted, all remaining sections are reassigned consecutive IDs and display letters (A, B, C, D, E…) with no gaps. Also resolves a post-login loading stuck issue in the auth context.

### Problem
When sections were deleted from the LCL Template, the remaining sections did not renumber consecutively. For example, deleting sections E, F, and G left section H still labeled "SECTION H" instead of being renumbered to "SECTION E". This was caused by the old `renumberSectionDisplayNames()` only updating display names for sections immediately after the deleted one, while leaving section IDs (e.g., `section_h`) unchanged — creating a mismatch between IDs and displayed letters.

Additionally, users reported the app getting stuck on a loading screen after login.

### Solution
Replaced the partial renumbering logic with a full section array rebuild: the deleted section is removed, all remaining sections are reassigned consecutive letter-based IDs (`section_a`, `section_b`, etc.), display names are updated to match, subsection IDs are rebuilt accordingly, and all `lcl_template_items` referencing old IDs are updated to the new IDs. A hard timeout was also added to the sign-in flow to prevent the loading state from getting stuck.

### Key Changes
- **`lclTemplateService.ts` — `renumberSectionDisplayNames()`**: Completely rebuilt to:
  - Filter out the deleted section from the sections array
  - Reassign consecutive letter-based IDs to all remaining sections and their subsections
  - Build an `oldId → newId` mapping for both sections and subsections
  - Update all `lcl_template_items` referencing old section/subsection IDs to their new values
- **`LCLTemplateEditor.tsx`**: Updated the delete confirmation dialog text to accurately reflect that all items in the section will be deleted from the template (not just the BOQ)
- **`AuthContext.tsx`**: Added a 3-second hard timeout in `signIn()` to force-clear the loading state if the auth flow stalls, and set `initializingRef.current = false` in `completeInit()` to prevent stuck initialization


---

<a href="https://builder.io/app/projects/8699340f4fdb476f894d/mono-speed-qt3tqxrj"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://8699340f4fdb476f894d-mono-speed-qt3tqxrj_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=8699340f4fdb476f894d&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 297`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8699340f4fdb476f894d</projectId>-->
<!--<branchName>mono-speed-qt3tqxrj</branchName>-->