### PR TITLE
Auto-renumber section labels on name edit in LCL BOQ

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -450,27 +450,88 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     setEditingSectionName(getDisplaySectionName(currentName));
   };
 
-  const handleSaveSectionTitle = (sectionLetter: string) => {
+  const handleSaveSectionTitle = async (sectionLetter: string) => {
     if (!editingSectionName.trim()) {
       return;
     }
 
-    setItems((prev) => {
-      const updatedItems = prev.map((item) => {
-        if (getSectionLetter(item.section_id) === sectionLetter) {
-          return {
-            ...item,
-            section_name: buildSectionDisplayHeader(sectionLetter, editingSectionName),
-          };
+    const newSectionName = editingSectionName;
+
+    // If linked to a template structure, trigger renumbering on the template
+    if (structureId && templateStructure) {
+      try {
+        // Find the section ID from the template structure that corresponds to this letter
+        const section = templateStructure.structure_data.sections.find(
+          (s: any) => getSectionLetter(s.id) === sectionLetter
+        );
+
+        if (section) {
+          // Ensure section letters are sequential in the template
+          await lclTemplateService.ensureSectionLettersAreSequential(structureId);
+
+          // Reload data from the template
+          const updatedHierarchy = await lclTemplateService.getHierarchicalData(structureId);
+
+          // Flatten and update items with new section names from the template
+          const updatedItems = flattenHierarchyToSnapshot(updatedHierarchy);
+          setItems(updatedItems);
         }
-        return item;
-      });
-      return updatedItems;
-    });
+      } catch (error) {
+        console.error('Failed to renumber sections:', error);
+        // Fall back to local renumbering if template sync fails
+        applyLocalSectionRenumbering(sectionLetter, newSectionName);
+      }
+    } else {
+      // For unlinked snapshots, use local relabeling only
+      applyLocalSectionRenumbering(sectionLetter, newSectionName);
+    }
 
     setDraftPending(true);
     setEditingSectionLetter(null);
     setEditingSectionName('');
+  };
+
+  const applyLocalSectionRenumbering = (editingSectionLetter: string, newSectionName: string) => {
+    setItems((prev) => {
+      // Extract all unique section letters and sort them
+      const sectionLetters = new Set<string>();
+      prev.forEach((item) => {
+        const letter = getSectionLetter(item.section_id);
+        if (letter) {
+          sectionLetters.add(letter);
+        }
+      });
+
+      const sortedLetters = Array.from(sectionLetters).sort();
+
+      // Create mapping of old letters to new letters
+      const letterMap = new Map<string, string>();
+      sortedLetters.forEach((letter, index) => {
+        const newLetter = String.fromCharCode(65 + index);
+        letterMap.set(letter, newLetter);
+      });
+
+      // Update items with new section names based on renumbered letters
+      const updatedItems = prev.map((item) => {
+        const oldLetter = getSectionLetter(item.section_id);
+        const newLetter = letterMap.get(oldLetter);
+
+        if (newLetter && oldLetter !== newLetter) {
+          return {
+            ...item,
+            section_name: buildSectionDisplayHeader(newLetter, newSectionName),
+          };
+        } else if (oldLetter === editingSectionLetter) {
+          return {
+            ...item,
+            section_name: buildSectionDisplayHeader(oldLetter, newSectionName),
+          };
+        }
+        return item;
+      });
+
+      return updatedItems;
+    });
   };
 
   const handleCancelEditSection = () => {

--- a/src/components/lclTemplate/LCLTemplateEditor.tsx
+++ b/src/components/lclTemplate/LCLTemplateEditor.tsx
@@ -702,6 +702,9 @@ export function LCLTemplateEditor({
         },
       });
 
+      // Trigger section letter sequencing to ensure consistency
+      await lclTemplateService.ensureSectionLettersAreSequential(data.structure_id);
+
       // Also update section names in current inline edits context if needed
       const updatedInlineEdits = { ...inlineEdits };
       setInlineEdits(updatedInlineEdits);

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -371,6 +371,91 @@ export class LCLTemplateService {
     return await this.getStructure(structureId);
   }
 
+  async ensureSectionLettersAreSequential(
+    structureId: string
+  ): Promise<LCLTemplateStructure> {
+    const structure = await this.getStructure(structureId);
+    const sections = structure.structure_data.sections;
+
+    // Create mapping of old section IDs to new section IDs with consecutive letters
+    const sectionIdMap = new Map<string, string>();
+    const updatedSections = sections.map((section: any, index: number) => {
+      const newLetter = String.fromCharCode(65 + index);
+      const oldId = section.id;
+      const newId = `section_${newLetter.toLowerCase()}`;
+
+      sectionIdMap.set(oldId, newId);
+
+      // Extract custom name and update with new letter
+      const nameMatch = section.name.match(/^(?:SECTION|Section)\s+[A-Z]:\s*(.+)$/);
+      const customName = nameMatch ? nameMatch[1] : section.name;
+
+      // Also rebuild subsection IDs to match the new section ID
+      const updatedSubsections = section.subsections.map(
+        (subsection: any) => {
+          const oldSubsectionId = subsection.id;
+          const oldLetter = oldId.match(/section_([a-z])/)?.[1] || '';
+          const newLetter = newId.match(/section_([a-z])/)?.[1] || '';
+          const newSubsectionId = oldSubsectionId.replace(
+            new RegExp(oldLetter, 'g'),
+            newLetter
+          );
+          sectionIdMap.set(oldSubsectionId, newSubsectionId);
+          return {
+            ...subsection,
+            id: newSubsectionId,
+          };
+        }
+      );
+
+      return {
+        ...section,
+        id: newId,
+        name: `SECTION ${newLetter}: ${customName}`,
+        subsections: updatedSubsections,
+      };
+    });
+
+    // Only update if there are actual changes
+    const hasChanges = sectionIdMap.size > sections.length;
+    if (!hasChanges) {
+      return structure;
+    }
+
+    // Update all item references to use new section and subsection IDs
+    const items = await this.getStructureItems(structureId);
+    for (const item of items) {
+      const newSectionId = sectionIdMap.get(item.section_id);
+      const newSubsectionId = sectionIdMap.get(item.subsection_id);
+
+      if (newSectionId && newSubsectionId) {
+        await this.updateItem(item.id, {
+          section_id: newSectionId,
+          subsection_id: newSubsectionId,
+        });
+      } else if (newSectionId && !newSubsectionId) {
+        const oldLetter = item.section_id.match(/section_([a-z])/)?.[1] || '';
+        const newLetterFromId = newSectionId.match(/section_([a-z])/)?.[1] || '';
+        const newSubId = item.subsection_id
+          .replace(item.section_id, newSectionId)
+          .replace(new RegExp(oldLetter, 'g'), newLetterFromId);
+        await this.updateItem(item.id, {
+          section_id: newSectionId,
+          subsection_id: newSubId,
+        });
+      }
+    }
+
+    // Persist updated sections
+    await this.updateStructure(structureId, {
+      structure_data: {
+        sections: updatedSections,
+      },
+    });
+
+    return await this.getStructure(structureId);
+  }
+
   async addSection(
     structureId: string,
     customName?: string


### PR DESCRIPTION
### Summary
Adds automatic section letter renumbering when a section name is edited in the LCL BOQ editor, ensuring section labels remain sequential (A, B, C, …) even after edits.

### Problem
When editing a section name in the LCL BOQ (e.g. renaming "Roofing" to "Roofings"), the section label did not update to follow the correct sequential order. This caused gaps in section lettering (e.g. jumping from D to H) instead of maintaining a continuous A, B, C sequence.

### Solution
Introduced a dedicated `ensureSectionLettersAreSequential` method in `lclTemplateService` that remaps section and subsection IDs to consecutive letters. The BOQ item editor now calls this method (for template-linked BOQs) or applies local renumbering (for unlinked snapshots) whenever a section name is saved.

### Key Changes
- **`lclTemplateService.ts`**: Added `ensureSectionLettersAreSequential` method that:
  - Rebuilds section and subsection IDs to use consecutive letters (A, B, C, …)
  - Updates all item references (`section_id`, `subsection_id`) to match the new IDs
  - Persists the updated structure back to the database
- **`LCLBOQItemEditor.tsx`**: Refactored `handleSaveSectionTitle` to:
  - Call `ensureSectionLettersAreSequential` and reload hierarchy data for template-linked BOQs
  - Fall back to a new `applyLocalSectionRenumbering` helper for unlinked snapshots
  - `applyLocalSectionRenumbering` sorts existing section letters and remaps them sequentially in local state
- **`LCLTemplateEditor.tsx`**: Triggers `ensureSectionLettersAreSequential` after saving a section name to keep the template structure consistent

---

<a href="https://builder.io/app/projects/be838b675e204c5087fb/copper-merge-ijcsxhna"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://be838b675e204c5087fb-copper-merge-ijcsxhna_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=be838b675e204c5087fb&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 298`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>be838b675e204c5087fb</projectId>-->
<!--<branchName>copper-merge-ijcsxhna</branchName>-->