### PR TITLE
Fix LCL BOQ page instability on load

### DIFF
--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -21,7 +21,7 @@ import {
 import { Download, Save } from 'lucide-react';
 
 export default function LCLTemplate() {
-  const { currentCompany } = useCurrentCompany();
+  const { currentCompany, isLoading: isCompanyLoading } = useCurrentCompany();
   const companyId = currentCompany?.id || '';
   const { toast } = useToast();
   const { data: customers } = useCustomers(companyId);
@@ -44,7 +44,7 @@ export default function LCLTemplate() {
   const [initialItems, setInitialItems] = useState<ItemSnapshot[]>([]);
   const [structureId, setStructureId] = useState<string>('');
 
-  const loadLCLBOQData = async () => {
+  const loadLCLBOQData = useCallback(async () => {
     if (!companyId) return;
 
     setLoading(true);
@@ -106,7 +106,7 @@ export default function LCLTemplate() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [companyId, toast]);
 
   const handleSaveLCLBOQ = async () => {
     if (!hierarchicalData || !companyId) return;
@@ -282,8 +282,9 @@ export default function LCLTemplate() {
   };
 
   useEffect(() => {
+    if (isCompanyLoading) return;
     loadLCLBOQData();
-  }, [companyId]);
+  }, [loadLCLBOQData, isCompanyLoading]);
 
   // Autosave header fields to localStorage (2s debounce)
   useEffect(() => {
@@ -319,7 +320,7 @@ export default function LCLTemplate() {
     } catch { /* ignore */ }
   }, [hierarchicalData]);
 
-  if (loading) {
+  if (loading || isCompanyLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <p className="text-muted-foreground">Loading LCL BOQ...</p>


### PR DESCRIPTION
### Summary
This PR fixes the LCL BOQ page instability where the page would briefly load and then redirect back to the dashboard due to a premature data fetch before the company context was ready.

### Problem
The LCL BOQ page was unstable — it would load momentarily and then refresh back to the dashboard. This was caused by `loadLCLBOQData` being triggered before `currentCompany` had finished loading, resulting in an empty `companyId` and a failed or aborted data fetch.

### Solution
The fix guards the data load effect against the company loading state, ensuring `loadLCLBOQData` is only called once `currentCompany` is fully resolved. The loading UI is also extended to cover the company-loading phase.

### Key Changes
- Imported `useCallback` and wrapped `loadLCLBOQData` in `useCallback` with proper dependencies (`companyId`, `toast`) to stabilize the function reference
- Extracted `isLoading` (as `isCompanyLoading`) from `useCurrentCompany` to track when company data is still being fetched
- Added an early return in the `useEffect` if `isCompanyLoading` is `true`, preventing premature data fetches with an empty `companyId`
- Updated the loading guard (`if (loading || isCompanyLoading)`) so the loading spinner is shown during both the company-fetch and BOQ-fetch phases


---

<a href="https://builder.io/app/projects/0983afd6a10e45908921/linear-generator-h0v2rxhk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://0983afd6a10e45908921-linear-generator-h0v2rxhk_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=0983afd6a10e45908921&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 299`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0983afd6a10e45908921</projectId>-->
<!--<branchName>linear-generator-h0v2rxhk</branchName>-->