### PR TITLE
Fix empty section display and Supabase credentials

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -776,9 +776,14 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     }
   };
 
-  // Group items by section for rendering — derive from data.sections so empty sections still appear
+  const hasItemsInSection = (sectionLetter: string): boolean => {
+    return items.some((item) => getSectionLetter(item.section_id) === sectionLetter);
+  };
+
+  // Group items by section for rendering — filter out empty sections
   const sectionLettersFromData = data.sections.map((s) => getSectionLetter(s.section_id));
-  const sectionLetters = Array.from(new Set([...sectionLettersFromData, ...items.map((item) => getSectionLetter(item.section_id))])).sort();
+  const allSectionLetters = Array.from(new Set([...sectionLettersFromData, ...items.map((item) => getSectionLetter(item.section_id))])).sort();
+  const sectionLetters = allSectionLetters.filter((letter) => hasItemsInSection(letter));
 
   return (
     <div className="space-y-4">

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,13 +2,9 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-// Use environment variables (required, no fallback to stale hardcoded values)
-export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
-export const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
-
-if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
-  console.warn('⚠️ Supabase credentials not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY environment variables.');
-}
+// Hardcoded Supabase credentials for project eubrvlzkvzevidivsfha
+export const SUPABASE_URL = 'https://eubrvlzkvzevidivsfha.supabase.co';
+export const SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_NlYHzHOT9LzEHgNuNfk_Ag_JBvPUWKF';
 
 console.log('✅ Supabase client initializing with URL:', SUPABASE_URL.substring(0, 30) + '...');
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,9 +2,9 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-// Use environment variables with fallback to hardcoded values
-export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || 'https://eubrvlzkvzevidivsfha.supabase.co';
-export const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV1YnJ2bHprdnpldmlkaXZzZmhhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgwNjA4NTgsImV4cCI6MjA3MzYzNjg1OH0.ni7Ogq-dKLvnCDzi8KvUVG2c1P7s0qY4xdF4AuvKwKk';
+// Use environment variables (required, no fallback to stale hardcoded values)
+export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+export const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
   console.warn('⚠️ Supabase credentials not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY environment variables.');


### PR DESCRIPTION
### Summary
This PR fixes the LCL BOQ item editor to hide empty sections from the UI and updates the Supabase client to use hardcoded credentials directly in code.

### Problem
Empty sections (with no items) were being rendered in the LCL BOQ item editor, causing non-sequential section letters to appear in the UI (e.g., section E followed by section I, with gaps for empty sections in between). Additionally, the Supabase client was relying on environment variables that were not reliably available, causing silent login failures.

### Solution
- Filter out sections that contain no items before rendering, so only populated sections are displayed with contiguous letters.
- Replace the environment-variable-based Supabase credential lookup with hardcoded values directly in the client file.

### Key Changes
- **`LCLBOQItemEditor.tsx`**: Added `hasItemsInSection` helper that checks whether any item belongs to a given section letter. The rendered `sectionLetters` array is now filtered to exclude empty sections, preventing gaps in the displayed section sequence.
- **`src/integrations/supabase/client.ts`**: Removed the `import.meta.env` fallback logic and warning; `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` are now hardcoded constants pointing to the project `eubrvlzkvzevidivsfha`.


---

<a href="https://builder.io/app/projects/905e4bd42d9147e99204/cosmic-hole-4nvla0ky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://905e4bd42d9147e99204-cosmic-hole-4nvla0ky_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=905e4bd42d9147e99204&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 301`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>905e4bd42d9147e99204</projectId>-->
<!--<branchName>cosmic-hole-4nvla0ky</branchName>-->