### PR TITLE
Fix section cleanup after item deletion in LCL BOQ editor

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -379,10 +379,14 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
       if (structureId && templateStructure) {
         lclTemplateService
           .renumberSectionDisplayNames(structureId, removeConfirm.id)
-          .then(() => {
-            const structure = templateStructure.structure_data;
-            const cleanedSections = lclTemplateService.deleteEmptySections(structure.sections);
-            if (cleanedSections.length < structure.sections.length) {
+          .then(async () => {
+            const updatedStructure = await lclTemplateService.getStructure(structureId);
+            const allItems = await lclTemplateService.getStructureItems(structureId);
+            const cleanedSections = lclTemplateService.deleteEmptySections(
+              updatedStructure.structure_data.sections,
+              allItems
+            );
+            if (cleanedSections.length < updatedStructure.structure_data.sections.length) {
               return lclTemplateService.updateStructure(structureId, {
                 structure_data: { sections: cleanedSections },
               });

--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -376,10 +376,19 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
       });
 
       // Best-effort persist; never let a failure navigate or throw
-      if (structureId) {
+      if (structureId && templateStructure) {
         lclTemplateService
           .renumberSectionDisplayNames(structureId, removeConfirm.id)
-          .catch((error) => console.error('Failed to renumber sections:', error));
+          .then(() => {
+            const structure = templateStructure.structure_data;
+            const cleanedSections = lclTemplateService.deleteEmptySections(structure.sections);
+            if (cleanedSections.length < structure.sections.length) {
+              return lclTemplateService.updateStructure(structureId, {
+                structure_data: { sections: cleanedSections },
+              });
+            }
+          })
+          .catch((error) => console.error('Failed to clean up sections:', error));
       }
 
       toast({ title: 'Success', description: `Section removed and remaining sections renumbered.` });
@@ -776,14 +785,10 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     }
   };
 
-  const hasItemsInSection = (sectionLetter: string): boolean => {
-    return items.some((item) => getSectionLetter(item.section_id) === sectionLetter);
-  };
-
-  // Group items by section for rendering — filter out empty sections
+  // Group items by section for rendering
   const sectionLettersFromData = data.sections.map((s) => getSectionLetter(s.section_id));
   const allSectionLetters = Array.from(new Set([...sectionLettersFromData, ...items.map((item) => getSectionLetter(item.section_id))])).sort();
-  const sectionLetters = allSectionLetters.filter((letter) => hasItemsInSection(letter));
+  const sectionLetters = allSectionLetters;
 
   return (
     <div className="space-y-4">

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -507,15 +507,11 @@ export class LCLTemplateService {
   }
 
   deleteEmptySections(
-    sections: any[]
+    sections: any[],
+    items: LCLTemplateItem[]
   ): any[] {
     return sections.filter((section) => {
-      for (const subsection of section.subsections || []) {
-        if (subsection.id) {
-          return true;
-        }
-      }
-      return false;
+      return items.some((item) => item.section_id === section.id);
     });
   }
 

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -506,6 +506,19 @@ export class LCLTemplateService {
     });
   }
 
+  deleteEmptySections(
+    sections: any[]
+  ): any[] {
+    return sections.filter((section) => {
+      for (const subsection of section.subsections || []) {
+        if (subsection.id) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+
   async recordHistory(
     structureId: string,
     companyId: string,


### PR DESCRIPTION
### Summary
This PR fixes an issue where deleting a section would succeed only once, with subsequent deletions showing a success toast but not actually removing the section. It adds proper cleanup of empty sections after renumbering.

### Problem
After removing a section and renumbering, empty sections were not being pruned from the structure data in the database. This caused subsequent delete operations to appear to succeed (toast shown) but have no visible effect, since stale empty sections remained in the persisted structure.

### Solution
After renumbering section display names, the editor now fetches the latest structure and its items, computes which sections have become empty, and removes them by updating the structure in the database. A new `deleteEmptySections` utility method on `LCLTemplateService` encapsulates this filtering logic.

### Key Changes
- **`LCLTemplateService.deleteEmptySections`**: New method that filters out sections with no associated items, based on `section_id` matching.
- **`LCLBOQItemEditor` — section removal flow**: After `renumberSectionDisplayNames` resolves, the editor fetches the updated structure and items, calls `deleteEmptySections`, and persists the cleaned sections if any were removed.
- **Section rendering**: Removed the `hasItemsInSection` filter that was hiding empty sections from the UI, so all sections (including newly added empty ones) are rendered — cleanup is now handled at the persistence layer instead.


---

<a href="https://builder.io/app/projects/eb7536cf6cfe48739e61/quasi-catalog-nqelyolk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://eb7536cf6cfe48739e61-quasi-catalog-nqelyolk_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=eb7536cf6cfe48739e61&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 302`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>eb7536cf6cfe48739e61</projectId>-->
<!--<branchName>quasi-catalog-nqelyolk</branchName>-->