### PR TITLE
Fix LCL BOQ section deletion async chain and ID mapping

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -391,6 +391,12 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
               structure_data: { sections: cleanedSections },
             });
           }
+
+          // 3. Fetch fresh hierarchical data and update items to sync with backend
+          const updatedHierarchy = await lclTemplateService.getHierarchicalData(structureId);
+          const updatedItems = flattenHierarchyToSnapshot(updatedHierarchy);
+          setItems(updatedItems);
+
           toast({ title: 'Success', description: `Section removed and remaining sections renumbered.` });
         } catch (error) {
           console.error('Failed to delete section:', error);

--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -360,6 +360,7 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
     if (!removeConfirm) return;
     setDraftPending(true);
     if (removeConfirm.type === 'section') {
+      // 1. Update local state immediately for snappy UI
       setItems((prev) => {
         const filtered = prev.filter((item) => item.section_id !== removeConfirm.id);
         const relabeled = relabelSectionsLocally(filtered);
@@ -375,27 +376,29 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
         return relabeled;
       });
 
-      // Best-effort persist; never let a failure navigate or throw
+      // 2. Persist to backend with proper error handling
       if (structureId && templateStructure) {
-        lclTemplateService
-          .renumberSectionDisplayNames(structureId, removeConfirm.id)
-          .then(async () => {
-            const updatedStructure = await lclTemplateService.getStructure(structureId);
-            const allItems = await lclTemplateService.getStructureItems(structureId);
-            const cleanedSections = lclTemplateService.deleteEmptySections(
-              updatedStructure.structure_data.sections,
-              allItems
-            );
-            if (cleanedSections.length < updatedStructure.structure_data.sections.length) {
-              return lclTemplateService.updateStructure(structureId, {
-                structure_data: { sections: cleanedSections },
-              });
-            }
-          })
-          .catch((error) => console.error('Failed to clean up sections:', error));
+        try {
+          await lclTemplateService.renumberSectionDisplayNames(structureId, removeConfirm.id);
+          const updatedStructure = await lclTemplateService.getStructure(structureId);
+          const allItems = await lclTemplateService.getStructureItems(structureId);
+          const cleanedSections = lclTemplateService.deleteEmptySections(
+            updatedStructure.structure_data.sections,
+            allItems
+          );
+          if (cleanedSections.length < updatedStructure.structure_data.sections.length) {
+            await lclTemplateService.updateStructure(structureId, {
+              structure_data: { sections: cleanedSections },
+            });
+          }
+          toast({ title: 'Success', description: `Section removed and remaining sections renumbered.` });
+        } catch (error) {
+          console.error('Failed to delete section:', error);
+          toast({ title: 'Error', description: 'Failed to delete section. Please try again.' });
+        }
+      } else {
+        toast({ title: 'Success', description: `Section removed and remaining sections renumbered.` });
       }
-
-      toast({ title: 'Success', description: `Section removed and remaining sections renumbered.` });
     } else {
       setItems((prev) => prev.filter((item) => getEditKey(item, -1) !== removeConfirm.id));
       setInlineEdits((edits) => {

--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -799,8 +799,8 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
   };
 
   // Group items by section for rendering
-  const sectionLettersFromData = data.sections.map((s) => getSectionLetter(s.section_id));
-  const allSectionLetters = Array.from(new Set([...sectionLettersFromData, ...items.map((item) => getSectionLetter(item.section_id))])).sort();
+  // Use only items to determine which sections to display (not data.sections, which may be stale)
+  const allSectionLetters = Array.from(new Set(items.map((item) => getSectionLetter(item.section_id)))).sort();
   const sectionLetters = allSectionLetters;
 
   return (

--- a/src/services/lclTemplateService.ts
+++ b/src/services/lclTemplateService.ts
@@ -313,12 +313,12 @@ export class LCLTemplateService {
         (subsection: any) => {
           const oldSubsectionId = subsection.id;
           // Subsection IDs follow pattern: section_X_X_name, where X is the letter
-          // Replace both occurrences: section_d_d_name -> section_c_c_name
+          // Replace only the section prefix: section_d_... -> section_c_...
           const oldLetter = oldId.match(/section_([a-z])/)?.[1] || '';
           const newLetter = newId.match(/section_([a-z])/)?.[1] || '';
           const newSubsectionId = oldSubsectionId.replace(
-            new RegExp(oldLetter, 'g'),
-            newLetter
+            new RegExp(`^section_${oldLetter}`),
+            `section_${newLetter}`
           );
           sectionIdMap.set(oldSubsectionId, newSubsectionId);
           return {
@@ -397,8 +397,8 @@ export class LCLTemplateService {
           const oldLetter = oldId.match(/section_([a-z])/)?.[1] || '';
           const newLetter = newId.match(/section_([a-z])/)?.[1] || '';
           const newSubsectionId = oldSubsectionId.replace(
-            new RegExp(oldLetter, 'g'),
-            newLetter
+            new RegExp(`^section_${oldLetter}`),
+            `section_${newLetter}`
           );
           sectionIdMap.set(oldSubsectionId, newSubsectionId);
           return {


### PR DESCRIPTION
### Summary
Fixes multiple failures in the LCL BOQ section deletion flow by properly awaiting the async cleanup chain, refreshing state from the backend after deletion, and correcting a dangerous global regex replacement that corrupted subsection IDs.

### Problem
Section deletion appeared to succeed on the first attempt but failed silently on subsequent deletions. Three root causes were identified:
1. The async cleanup chain was not awaited — errors were swallowed and the UI always reported success regardless of outcome.
2. Subsection ID renumbering used a global regex (`replace(new RegExp(oldLetter, 'g'), newLetter)`) that replaced every occurrence of the letter in the ID string, corrupting IDs where the letter appeared in the name portion.
3. After a deletion, the component retained stale state, causing subsequent deletions to reference outdated data.

### Solution
- Converted the fire-and-forget `.then()/.catch()` chain in `confirmRemove()` to a proper `async/await` block wrapped in `try/catch`.
- After a successful backend cleanup, fetch fresh hierarchical data and sync local item state to the backend truth.
- Replaced the global regex with an anchored prefix-only regex (`^section_${oldLetter}`) so only the section prefix is remapped, not occurrences in the name portion.
- Derived displayed section letters solely from the current `items` state rather than the potentially stale `data.sections`.

### Key Changes
- **`LCLBOQItemEditor.tsx` — `confirmRemove()`**:
  - Awaits the full deletion/renumbering/cleanup chain instead of using a detached promise.
  - Fetches fresh hierarchical data via `getHierarchicalData()` and flattens it back to snapshot items after successful cleanup.
  - Shows an error toast on failure instead of always reporting success.
  - Section letter list now derived exclusively from live `items` state, eliminating stale `data.sections` references.
- **`lclTemplateService.ts` — `renumberSectionDisplayNames()` and `ensureSectionLettersAreSequential()`**:
  - Replaced `new RegExp(oldLetter, 'g')` with `new RegExp('^section_${oldLetter}')` to safely target only the section prefix in subsection IDs.


---

<a href="https://builder.io/app/projects/f3d2b46e5c6e485ba92d/stellar-retreat-irgd1ssk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://f3d2b46e5c6e485ba92d-stellar-retreat-irgd1ssk_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=f3d2b46e5c6e485ba92d&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 303`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f3d2b46e5c6e485ba92d</projectId>-->
<!--<branchName>stellar-retreat-irgd1ssk</branchName>-->