### PR TITLE
Fix LCL BOQ templates page loading issue

### DIFF
--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -21,10 +21,13 @@ import {
 import { Download, Save } from 'lucide-react';
 
 export default function LCLTemplate() {
+  console.log('[LCLTemplate] Component mounted');
   const { currentCompany, isLoading: isCompanyLoading } = useCurrentCompany();
   const companyId = currentCompany?.id || '';
   const { toast } = useToast();
   const { data: customers } = useCustomers(companyId);
+
+  console.log(`[LCLTemplate] Company context - isLoading: ${isCompanyLoading}, companyId: ${companyId}`);
 
   const [hierarchicalData, setHierarchicalData] =
     useState<LCLHierarchicalData | null>(null);
@@ -293,7 +296,12 @@ export default function LCLTemplate() {
   };
 
   useEffect(() => {
-    if (isCompanyLoading) return;
+    console.log(`[LCLTemplate] useEffect triggered - isCompanyLoading: ${isCompanyLoading}`);
+    if (isCompanyLoading) {
+      console.log('[LCLTemplate] Company still loading, skipping loadLCLBOQData');
+      return;
+    }
+    console.log('[LCLTemplate] Calling loadLCLBOQData');
     loadLCLBOQData();
   }, [loadLCLBOQData, isCompanyLoading]);
 

--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -46,23 +46,31 @@ export default function LCLTemplate() {
 
   const loadLCLBOQData = useCallback(async () => {
     if (!companyId) {
+      console.warn('[LCLTemplate] Company ID is empty, skipping data load');
       setLoading(false);
       return;
     }
 
     setLoading(true);
+    console.log(`[LCLTemplate] Loading LCL BOQ data for company: ${companyId}`);
     try {
       // Load the default LCL BOQ structure for this company
       const structures = await lclTemplateService.getStructures(companyId);
+      console.log(`[LCLTemplate] Loaded structures: ${structures.length} structure(s) - ${structures.map((s) => s.name).join(', ')}`);
+
       const lclDefaultStructure = structures.find(
         (s) => s.name === 'LCL Default BOQ'
       );
 
       if (!lclDefaultStructure) {
+        const structureNames = structures.length > 0
+          ? structures.map((s) => s.name).join(', ')
+          : 'none';
+        const errorMsg = `LCL Default BOQ structure not found. Found ${structures.length} structure(s): ${structureNames}`;
+        console.error(`[LCLTemplate] ${errorMsg}`);
         toast({
           title: 'Error',
-          description:
-            'LCL Default BOQ structure not found. Please contact support.',
+          description: errorMsg,
           variant: 'destructive',
         });
         setLoading(false);
@@ -70,8 +78,10 @@ export default function LCLTemplate() {
       }
 
       // Load hierarchical data for the default structure
+      console.log(`[LCLTemplate] Loading hierarchical data for structure ID: ${lclDefaultStructure.id}`);
       const data =
         await lclTemplateService.getHierarchicalData(lclDefaultStructure.id);
+      console.log(`[LCLTemplate] Hierarchical data loaded successfully`);
       setHierarchicalData(data);
       setStructureId(lclDefaultStructure.id);
 
@@ -97,13 +107,11 @@ export default function LCLTemplate() {
         setBoqNumber('BOQ-001');
       }
     } catch (error) {
-      console.error('Error loading LCL BOQ:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Failed to load LCL BOQ';
+      console.error(`[LCLTemplate] Error loading LCL BOQ for company ${companyId}:`, error);
       toast({
         title: 'Error',
-        description:
-          error instanceof Error
-            ? error.message
-            : 'Failed to load LCL BOQ',
+        description: errorMessage,
         variant: 'destructive',
       });
     } finally {


### PR DESCRIPTION
### Summary
Adds detailed diagnostic logging to the LCL BOQ Templates page to surface loading issues and improve error messaging when the page fails to load correctly.

### Problem
The LCL BOQ templates page was not loading properly — it would either fail silently or redirect unexpectedly, making it difficult to diagnose why the data was not being displayed.

### Solution
Added structured `console.log` and `console.error` statements throughout the component lifecycle and data-loading flow to trace exactly where failures occur. Error messages shown to the user were also improved to include more context (e.g., which structures were found vs. expected).

### Key Changes
- Added `[LCLTemplate]`-prefixed console logs at component mount, company context resolution, and `useEffect` trigger points
- Added logging inside `loadLCLBOQData` to trace each step: company ID check, structure fetch, hierarchical data fetch
- Improved the "LCL Default BOQ structure not found" error message to include the names of structures that were actually found
- Extracted error message construction into a variable for cleaner toast usage
- Added a warning log when `companyId` is empty and data load is skipped


---

<a href="https://builder.io/app/projects/a04cec443a874bc39a70/equator-grid-uyiyhql1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://a04cec443a874bc39a70-equator-grid-uyiyhql1_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=a04cec443a874bc39a70&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 304`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a04cec443a874bc39a70</projectId>-->
<!--<branchName>equator-grid-uyiyhql1</branchName>-->