### PR TITLE
Fix LCL template autosave and remove company ID gate

### DIFF
--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -43,6 +43,7 @@ export default function LCLTemplate() {
   const [lclBoqRecord, setLclBoqRecord] = useState<LCLBOQRecord | null>(null);
   const editorRef = useRef<LCLBOQItemEditorHandle>(null);
   const headerAutosaveRef = useRef<NodeJS.Timeout | null>(null);
+  const hasAttemptedRestoreRef = useRef(false);
 
   const [initialItems, setInitialItems] = useState<ItemSnapshot[]>([]);
   const [structureId, setStructureId] = useState<string>('');
@@ -313,6 +314,10 @@ export default function LCLTemplate() {
 
   // Autosave header fields to localStorage (2s debounce)
   useEffect(() => {
+    if (!hasAttemptedRestoreRef.current) {
+      return;
+    }
+
     if (headerAutosaveRef.current) {
       clearTimeout(headerAutosaveRef.current);
     }
@@ -340,15 +345,33 @@ export default function LCLTemplate() {
   // Restore header fields from localStorage after data loads
   useEffect(() => {
     if (!hierarchicalData) return;
+
+    let hasRestored = false;
     try {
       const raw = localStorage.getItem('lcl_boq_creation_header');
       if (raw) {
         const saved = JSON.parse(raw);
-        if (saved.selectedCustomerId) setSelectedCustomerId(saved.selectedCustomerId);
-        if (saved.projectTitle) setProjectTitle(saved.projectTitle);
-        if (saved.boqDate) setBoqDate(saved.boqDate);
+        if (saved.selectedCustomerId) {
+          setSelectedCustomerId(saved.selectedCustomerId);
+          hasRestored = true;
+        }
+        if (saved.projectTitle) {
+          setProjectTitle(saved.projectTitle);
+          hasRestored = true;
+        }
+        if (saved.boqDate) {
+          setBoqDate(saved.boqDate);
+          hasRestored = true;
+        }
       }
     } catch { /* ignore */ }
+
+    // Mark that we've attempted restoration so autosave can begin
+    hasAttemptedRestoreRef.current = true;
+
+    if (hasRestored) {
+      console.log('[LCLTemplate] ✅ Header fields restored from draft');
+    }
   }, [hierarchicalData]);
 
   if (loading || isCompanyLoading) {

--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -57,7 +57,7 @@ export default function LCLTemplate() {
 
   const loadLCLBOQData = useCallback(async () => {
     if (!companyId) {
-      console.warn('[LCLTemplate] Company ID is empty, skipping data load');
+      console.log('[LCLTemplate] Company ID not set yet, skipping data load');
       setLoading(false);
       return;
     }
@@ -304,11 +304,7 @@ export default function LCLTemplate() {
       console.log('[LCLTemplate] ⏳ Company still loading, skipping loadLCLBOQData until company context ready');
       return;
     }
-    if (!companyId) {
-      console.warn('[LCLTemplate] ⚠️ Company ID is empty, waiting for company context to populate');
-      return;
-    }
-    console.log('[LCLTemplate] 📊 Company ready, calling loadLCLBOQData');
+    console.log('[LCLTemplate] 📊 Calling loadLCLBOQData');
     loadLCLBOQData();
   }, [loadLCLBOQData, isCompanyLoading, companyId]);
 
@@ -382,20 +378,6 @@ export default function LCLTemplate() {
           {isCompanyLoading && <p className="text-xs text-muted-foreground/70">Waiting for company context...</p>}
           {loading && companyId && <p className="text-xs text-muted-foreground/70">Loading data for company: {companyId}</p>}
         </div>
-      </div>
-    );
-  }
-
-  if (!hierarchicalData) {
-    return (
-      <div className="flex flex-col items-center justify-center py-12 text-center space-y-4">
-        <div>
-          <p className="text-muted-foreground mb-2">
-            Unable to load LCL BOQ structure.
-          </p>
-          <p className="text-xs text-muted-foreground/70">Company: {companyId || 'Not loaded'}</p>
-        </div>
-        <Button onClick={loadLCLBOQData}>Try Again</Button>
       </div>
     );
   }


### PR DESCRIPTION
### Summary
This PR fixes the LCL BOQ template's autosave behavior by preventing it from firing before draft data has been restored, and removes the strict company ID check that was blocking the template from loading.

### Problem
The LCL BOQ template was autosaving header fields to localStorage before the restore step had a chance to run, causing draft data to be overwritten with empty values on load. Additionally, a hard company ID guard was preventing the template from rendering even when the company context was available, and an unnecessary "Unable to load" error screen was shown when `hierarchicalData` was absent.

### Solution
A `hasAttemptedRestoreRef` flag was introduced to gate the autosave effect, ensuring it only runs after the restore-from-localStorage step has completed. The redundant company ID check inside the load trigger effect was removed, and the `hierarchicalData` null error screen was eliminated.

### Key Changes
- Added `hasAttemptedRestoreRef` ref to track whether the localStorage restore has been attempted
- Autosave effect now returns early until `hasAttemptedRestoreRef.current` is `true`, preventing premature overwrites of draft data
- Restore effect sets `hasAttemptedRestoreRef.current = true` after attempting restoration, regardless of whether any data was found
- Removed the redundant `if (!companyId)` guard inside the load trigger `useEffect`, allowing `loadLCLBOQData` to be called as soon as the company context is ready
- Removed the `hierarchicalData` null error fallback UI (the "Unable to load LCL BOQ structure" screen)
- Downgraded the company ID log from `console.warn` to `console.log` for less alarming output

---

<a href="https://builder.io/app/projects/96f4af3af17d40d2ae33/silky-nest-lmv8v0gw"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://96f4af3af17d40d2ae33-silky-nest-lmv8v0gw_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=96f4af3af17d40d2ae33&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 307`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>96f4af3af17d40d2ae33</projectId>-->
<!--<branchName>silky-nest-lmv8v0gw</branchName>-->