### PR TITLE
Fix LCL BOQ number generation to use true max

### DIFF
--- a/src/utils/boqNumberGenerator.ts
+++ b/src/utils/boqNumberGenerator.ts
@@ -56,7 +56,7 @@ function generateNextBOQNumberSync(existingBOQs: Array<{ number: string }>): str
 }
 
 /**
- * Asynchronous version - fetches MAX() from both boqs and lcl_boqs tables
+ * Asynchronous version - fetches all BOQ numbers from both tables and finds true numeric maximum
  */
 async function generateNextBOQNumberAsync(
   existingBOQs: Array<{ number: string }> | undefined,
@@ -64,30 +64,41 @@ async function generateNextBOQNumberAsync(
 ): Promise<string> {
   let maxNumber = 0;
 
+  const extractNumber = (boqNumber: string): number => {
+    const match = boqNumber.match(/^BOQ-(\d{1,3})$/);
+    return match ? parseInt(match[1], 10) : 0;
+  };
+
   try {
     const [boqsResult, lclBoqsResult] = await Promise.all([
       supabase
         .from('boqs')
         .select('number')
-        .eq('company_id', companyId)
-        .order('number', { ascending: false })
-        .limit(1),
+        .eq('company_id', companyId),
       supabase
         .from('lcl_boqs')
         .select('number')
-        .eq('company_id', companyId)
-        .order('number', { ascending: false })
-        .limit(1),
+        .eq('company_id', companyId),
     ]);
 
-    const extractNumber = (boqNumber: string): number => {
-      const match = boqNumber.match(/^BOQ-(\d{1,3})$/);
-      return match ? parseInt(match[1], 10) : 0;
-    };
+    // Extract numeric values from all records and find true maximum
+    if (boqsResult.data && boqsResult.data.length > 0) {
+      boqsResult.data.forEach((boq) => {
+        const num = extractNumber(boq.number);
+        if (num > maxNumber) {
+          maxNumber = num;
+        }
+      });
+    }
 
-    const boqsMax = boqsResult.data?.[0] ? extractNumber(boqsResult.data[0].number) : 0;
-    const lclBoqsMax = lclBoqsResult.data?.[0] ? extractNumber(lclBoqsResult.data[0].number) : 0;
-    maxNumber = Math.max(boqsMax, lclBoqsMax);
+    if (lclBoqsResult.data && lclBoqsResult.data.length > 0) {
+      lclBoqsResult.data.forEach((boq) => {
+        const num = extractNumber(boq.number);
+        if (num > maxNumber) {
+          maxNumber = num;
+        }
+      });
+    }
   } catch (error) {
     console.error('Error fetching BOQ numbers:', error);
     maxNumber = 0;
@@ -96,12 +107,9 @@ async function generateNextBOQNumberAsync(
   // Apply local BOQs if provided
   if (existingBOQs && existingBOQs.length > 0) {
     existingBOQs.forEach((boq) => {
-      const match = boq.number.match(/^BOQ-(\d{1,3})$/);
-      if (match && match[1]) {
-        const numericPart = parseInt(match[1], 10);
-        if (!isNaN(numericPart) && numericPart > maxNumber) {
-          maxNumber = numericPart;
-        }
+      const num = extractNumber(boq.number);
+      if (num > maxNumber) {
+        maxNumber = num;
       }
     });
   }


### PR DESCRIPTION
### Summary
Fixes the BOQ number generator for LCL templates so that the next generated number correctly follows the unified sequence across both `boqs` and `lcl_boqs` tables.

### Problem
The LCL BOQ template was generating incorrect BOQ numbers because the previous implementation relied on database-side ordering with `.limit(1)` to find the maximum number. This approach could return incorrect results if the lexicographic ordering of BOQ strings (e.g. `BOQ-9` vs `BOQ-10`) didn't match true numeric order, causing the next number to be wrong.

### Solution
Instead of relying on database ordering, all BOQ numbers are now fetched from both tables and the true numeric maximum is computed in application code by parsing each `BOQ-NNN` string and iterating over all records.

### Key Changes
- Removed `.order('number', { ascending: false }).limit(1)` from both `boqs` and `lcl_boqs` queries; now fetches all records
- Moved `extractNumber` helper above the query block so it can be reused across all three iteration steps (boqs, lcl_boqs, and local existingBOQs)
- Iterates over all fetched records from both tables to find the true numeric maximum before generating the next number
- Simplified the `existingBOQs` local-override loop to reuse the shared `extractNumber` helper

---

<a href="https://builder.io/app/projects/d0976791e0e44f8fa653/parabolic-circuit-f3johkvq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://d0976791e0e44f8fa653-parabolic-circuit-f3johkvq_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=d0976791e0e44f8fa653&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 308`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d0976791e0e44f8fa653</projectId>-->
<!--<branchName>parabolic-circuit-f3johkvq</branchName>-->