### PR TITLE
Remove company ID display from LCL template loading screen

### DIFF
--- a/src/pages/LCLTemplate.tsx
+++ b/src/pages/LCLTemplate.tsx
@@ -376,7 +376,6 @@ export default function LCLTemplate() {
         <div className="text-center space-y-2">
           <p className="text-muted-foreground">Loading LCL BOQ...</p>
           {isCompanyLoading && <p className="text-xs text-muted-foreground/70">Waiting for company context...</p>}
-          {loading && companyId && <p className="text-xs text-muted-foreground/70">Loading data for company: {companyId}</p>}
         </div>
       </div>
     );


### PR DESCRIPTION
### Summary
Removes the company ID text that was being displayed on the LCL template loading screen, since the system is designed for a single company and exposing this detail is unnecessary.

### Problem
The LCL template page was displaying the company ID (e.g., "Loading data for company: `<id>`") during the loading state. Since the system is single-company, surfacing this internal identifier to users was unintended and unhelpful.

### Solution
Removed the conditional line that rendered the company ID message during the loading phase.

### Key Changes
- Removed the `{loading && companyId && <p>Loading data for company: {companyId}</p>}` line from the loading state UI in `LCLTemplate.tsx`


---

<a href="https://builder.io/app/projects/42d5c7664e7f4e8c843a/round-border-texccihe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://42d5c7664e7f4e8c843a-round-border-texccihe_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=42d5c7664e7f4e8c843a&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 309`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>42d5c7664e7f4e8c843a</projectId>-->
<!--<branchName>round-border-texccihe</branchName>-->