### PR TITLE
Fix autosave UI indicator visibility in LCL template

### DIFF
--- a/src/components/lcl/LCLBOQItemEditor.tsx
+++ b/src/components/lcl/LCLBOQItemEditor.tsx
@@ -231,7 +231,10 @@ export const LCLBOQItemEditor = forwardRef<LCLBOQItemEditorHandle, LCLBOQItemEdi
       } catch (error) {
         console.error('Failed to autosave draft:', error);
       } finally {
-        setIsSaving(false);
+        // Keep "Saving draft..." visible for at least 1 second for UX feedback
+        setTimeout(() => {
+          setIsSaving(false);
+        }, 1000);
       }
     }, 5000);
 


### PR DESCRIPTION
### Summary
This PR ensures the "Saving draft..." autosave indicator remains visible long enough for users to notice it by adding a minimum display duration after a save completes.

### Problem
The autosave status indicator ("Saving draft...") was not visibly appearing on the `/lcl-template` page. Even though the autosave logic was executing correctly, the `isSaving` flag was being set back to `false` immediately after the save completed, causing the indicator to flash too briefly (or not at all) to be seen by users.

### Solution
Added a 1-second delay before clearing the `isSaving` state after a successful autosave. This ensures the "Saving draft..." message remains visible for at least 1 second, giving users clear visual feedback that their changes are being saved.

### Key Changes
- **`LCLBOQItemEditor.tsx`**: Wrapped `setIsSaving(false)` in a `setTimeout` with a 1000ms delay inside the `finally` block of the autosave handler, so the saving indicator stays visible for at least 1 second after each autosave completes.


---

<a href="https://builder.io/app/projects/f2e3a5f246114b22a5b0/vortex-handle-3g8cnvei"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://f2e3a5f246114b22a5b0-vortex-handle-3g8cnvei_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=f2e3a5f246114b22a5b0&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 310`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f2e3a5f246114b22a5b0</projectId>-->
<!--<branchName>vortex-handle-3g8cnvei</branchName>-->