### PR TITLE
Fix LCL BOQ to use next number from BOQ table

### DIFF
--- a/src/services/lclBoqService.ts
+++ b/src/services/lclBoqService.ts
@@ -2,6 +2,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { BOQData } from '@/utils/boqHelper';
 import { reconstructHierarchicalDataFromSnapshot } from '@/utils/lclBoqPdfGenerator';
 import { generateUniqueInvoiceNumber } from '@/utils/invoiceNumberGenerator';
+import { invalidateBOQNumberCache } from '@/utils/boqNumberGenerator';
 
 export interface LCLBOQRecord {
   id?: string;
@@ -94,6 +95,12 @@ class LCLBOQService {
       }
 
       console.log('UPDATE successful', { id, updatedId: updated?.id, updatedAt: updated?.updated_at });
+
+      // Invalidate BOQ number cache when updating
+      if (updated?.company_id) {
+        invalidateBOQNumberCache(updated.company_id);
+      }
+
       return updated as LCLBOQRecord;
     } else {
       // Create new
@@ -114,6 +121,12 @@ class LCLBOQService {
       }
 
       console.log('INSERT successful', { createdId: created?.id });
+
+      // Invalidate BOQ number cache when creating new LCL BOQ
+      if (created?.company_id) {
+        invalidateBOQNumberCache(created.company_id);
+      }
+
       return created as LCLBOQRecord;
     }
   }
@@ -237,6 +250,8 @@ class LCLBOQService {
       created_by: createdBy,
     };
 
+    let result: BOQData;
+
     // Check if BOQ already exists by boq_id (for updates)
     if (lclBoq.boq_id) {
       const { data, error } = await supabase
@@ -250,42 +265,47 @@ class LCLBOQService {
         .single();
 
       if (error) throw error;
-      return data as BOQData;
-    }
-
-    // Check if BOQ with this number already exists for this company
-    const { data: existingBoq } = await supabase
-      .from('boqs')
-      .select('id')
-      .eq('company_id', lclBoq.company_id)
-      .eq('number', lclBoq.number)
-      .single();
-
-    if (existingBoq) {
-      // Update existing BOQ (shouldn't happen if boq_id is set, but fallback)
-      const { data, error } = await supabase
-        .from('boqs')
-        .update({
-          ...boqRecord,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', existingBoq.id)
-        .select()
-        .single();
-
-      if (error) throw error;
-      return data as BOQData;
+      result = data as BOQData;
     } else {
-      // Insert new BOQ
-      const { data, error } = await supabase
+      // Check if BOQ with this number already exists for this company
+      const { data: existingBoq } = await supabase
         .from('boqs')
-        .insert([boqRecord])
-        .select()
+        .select('id')
+        .eq('company_id', lclBoq.company_id)
+        .eq('number', lclBoq.number)
         .single();
 
-      if (error) throw error;
-      return data as BOQData;
+      if (existingBoq) {
+        // Update existing BOQ (shouldn't happen if boq_id is set, but fallback)
+        const { data, error } = await supabase
+          .from('boqs')
+          .update({
+            ...boqRecord,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', existingBoq.id)
+          .select()
+          .single();
+
+        if (error) throw error;
+        result = data as BOQData;
+      } else {
+        // Insert new BOQ
+        const { data, error } = await supabase
+          .from('boqs')
+          .insert([boqRecord])
+          .select()
+          .single();
+
+        if (error) throw error;
+        result = data as BOQData;
+      }
     }
+
+    // Invalidate BOQ number cache after creating/updating BOQ
+    invalidateBOQNumberCache(lclBoq.company_id);
+
+    return result;
   }
 }
 

--- a/src/utils/boqNumberGenerator.ts
+++ b/src/utils/boqNumberGenerator.ts
@@ -81,7 +81,8 @@ function invalidateCache(companyId: string): void {
 }
 
 /**
- * Asynchronous version - uses efficient SQL aggregate query instead of full table scan
+ * Asynchronous version - fetches all numbers and finds max in JavaScript
+ * to avoid lexicographic sorting issues from Supabase
  */
 async function generateNextBOQNumberAsync(
   existingBOQs: Array<{ number: string }> | undefined,
@@ -103,36 +104,36 @@ async function generateNextBOQNumberAsync(
   };
 
   try {
-    // Use RPC or raw SQL to get MAX number efficiently instead of fetching all rows
-    // Falls back to selecting all if RPC not available
+    // Fetch all numbers (no ordering) and find max in JavaScript
+    // to avoid lexicographic sorting issues in Supabase
     const [boqsResult, lclBoqsResult] = await Promise.all([
       supabase
         .from('boqs')
         .select('number')
-        .eq('company_id', companyId)
-        .order('number', { ascending: false })
-        .limit(1),
+        .eq('company_id', companyId),
       supabase
         .from('lcl_boqs')
         .select('number')
-        .eq('company_id', companyId)
-        .order('number', { ascending: false })
-        .limit(1),
+        .eq('company_id', companyId),
     ]);
 
-    // Extract numeric values from top results only
+    // Find numeric maximum across all results
     if (boqsResult.data && boqsResult.data.length > 0) {
-      const num = extractNumber(boqsResult.data[0].number);
-      if (num > maxNumber) {
-        maxNumber = num;
-      }
+      boqsResult.data.forEach((row) => {
+        const num = extractNumber(row.number);
+        if (num > maxNumber) {
+          maxNumber = num;
+        }
+      });
     }
 
     if (lclBoqsResult.data && lclBoqsResult.data.length > 0) {
-      const num = extractNumber(lclBoqsResult.data[0].number);
-      if (num > maxNumber) {
-        maxNumber = num;
-      }
+      lclBoqsResult.data.forEach((row) => {
+        const num = extractNumber(row.number);
+        if (num > maxNumber) {
+          maxNumber = num;
+        }
+      });
     }
   } catch (error) {
     console.error('Error fetching BOQ numbers:', error);


### PR DESCRIPTION
### Summary
This PR fixes LCL BOQ number generation to correctly derive the next sequential number by scanning all existing BOQ records and finding the true numeric maximum in JavaScript, rather than relying on lexicographic database ordering.

### Problem
LCL BOQ was reading `BOQ-001` instead of the next available number from the BOQ table. This was caused by Supabase's lexicographic ordering being used to find the highest BOQ number, which could return incorrect results (e.g., `BOQ-9` sorted higher than `BOQ-10`).

### Solution
Replaced the database-side `ORDER BY ... LIMIT 1` approach with a full fetch of all BOQ numbers from both `boqs` and `lcl_boqs` tables, then finding the numeric maximum in JavaScript. Additionally, the BOQ number cache is now invalidated after every create or update operation to ensure fresh numbers are always generated.

### Key Changes
- **`boqNumberGenerator.ts`**: Changed `generateNextBOQNumberAsync` to fetch all BOQ numbers without ordering and compute the numeric maximum in JavaScript, avoiding lexicographic sorting issues from Supabase.
- **`lclBoqService.ts`**: Added `invalidateBOQNumberCache` calls after every create and update operation (in both the `saveOrUpdate` and `syncToBoqTable` methods) to keep the cache consistent with the database state.
- Exported `invalidateBOQNumberCache` from `boqNumberGenerator.ts` for use in `lclBoqService.ts`.

---

<a href="https://builder.io/app/projects/1e5a8398a8c148ee93a9/gleam-crystal-vnhdvgli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://1e5a8398a8c148ee93a9-gleam-crystal-vnhdvgli_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=1e5a8398a8c148ee93a9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 315`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1e5a8398a8c148ee93a9</projectId>-->
<!--<branchName>gleam-crystal-vnhdvgli</branchName>-->