### PR TITLE
Redirect to original page after login instead of dashboard

### DIFF
--- a/src/components/auth/EnhancedLogin.tsx
+++ b/src/components/auth/EnhancedLogin.tsx
@@ -7,13 +7,14 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Loader2, Eye, EyeOff, Mail, Lock } from 'lucide-react';
 import { toast } from '@/utils/safeToast';
 import { handleAuthError } from '@/utils/authErrorHandler';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
 export function EnhancedLogin() {
   const { signIn, loading } = useAuth();
   const [submitting, setSubmitting] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -60,7 +61,8 @@ export function EnhancedLogin() {
         // Ensure error is properly formatted before passing to handler
         handleAuthError(error);
       } else {
-        navigate('/');
+        // Redirect back to the page the user was trying to access, or to dashboard
+        navigate(location.pathname || '/');
       }
     } catch (unexpectedError) {
       // Catch any unexpected errors and format them properly


### PR DESCRIPTION
### Summary
After a successful login, users are now redirected back to the page they were originally trying to access, rather than always being sent to the dashboard.

### Problem
The login flow unconditionally redirected users to `/` (dashboard) after a successful sign-in. This meant that if a user navigated directly to a specific page (e.g., the LCL BOQ page) and was prompted to log in, they would land on the dashboard instead of their intended destination, requiring extra navigation.

### Solution
Use React Router's `useLocation` hook to capture the current pathname at login time and redirect the user back to that path after a successful sign-in, falling back to `/` if no path is available.

### Key Changes
- Imported `useLocation` from `react-router-dom` in `EnhancedLogin.tsx`
- Replaced the hardcoded `navigate('/')` with `navigate(location.pathname || '/')` so users are returned to their originally requested page after login


---

<a href="https://builder.io/app/projects/0fe63d2e55734dd4af58/mystic-bastion-osqmjmke"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://0fe63d2e55734dd4af58-mystic-bastion-osqmjmke_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=0fe63d2e55734dd4af58&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 316`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0fe63d2e55734dd4af58</projectId>-->
<!--<branchName>mystic-bastion-osqmjmke</branchName>-->