### PR TITLE
Fix ProtectedRoute auth check with session fallback

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Card, CardContent } from '@/components/ui/card';
 import { Lock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/integrations/supabase/client';
 
 interface ProtectedRouteProps {
   children: ReactNode;

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,8 +1,9 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Card, CardContent } from '@/components/ui/card';
 import { Lock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { supabase } from '@/lib/supabase';
 
 interface ProtectedRouteProps {
   children: ReactNode;
@@ -16,9 +17,42 @@ export function ProtectedRoute({
   requireAuth = true,
 }: ProtectedRouteProps) {
   const { isAuthenticated, loading } = useAuth();
+  const [sessionVerified, setSessionVerified] = useState(false);
+  const [verifyingSession, setVerifyingSession] = useState(false);
 
-  // Show loading state
-  if (loading) {
+  useEffect(() => {
+    // If context says we're authenticated, no need to verify
+    if (isAuthenticated) {
+      setSessionVerified(true);
+      return;
+    }
+
+    // If still loading, wait for initial load
+    if (loading) {
+      return;
+    }
+
+    // If loading is complete and we're not authenticated, verify Supabase session as fallback
+    const verifySuperbaseSession = async () => {
+      setVerifyingSession(true);
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session) {
+          console.log('✅ [ProtectedRoute] Session verified via Supabase fallback');
+          setSessionVerified(true);
+        }
+      } catch (error) {
+        console.error('[ProtectedRoute] Error verifying session:', error);
+      } finally {
+        setVerifyingSession(false);
+      }
+    };
+
+    verifySuperbaseSession();
+  }, [isAuthenticated, loading]);
+
+  // Show loading state while checking session
+  if (loading || verifyingSession) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
@@ -29,8 +63,8 @@ export function ProtectedRoute({
     );
   }
 
-  // Check authentication
-  if (requireAuth && !isAuthenticated) {
+  // Check authentication: context state OR verified session
+  if (requireAuth && !isAuthenticated && !sessionVerified) {
     return fallback || (
       <div className="flex items-center justify-center min-h-[400px]">
         <Card className="w-full max-w-md text-center">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -342,11 +342,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       }
     };
 
-    // CRITICAL: Ensure initialization completes within 2 seconds no matter what
+    // CRITICAL: Ensure initialization completes within 1.5 seconds no matter what
     const hardTimeout = setTimeout(() => {
       console.warn('⚠️ Hard timeout: completing initialization');
       completeInit();
-    }, 2000);
+    }, 1500);
 
     const initializeAuthState = async () => {
       try {
@@ -362,7 +362,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
         // Simple session check with timeout
         const sessionTimeoutPromise = new Promise((_, reject) => {
-          setTimeout(() => reject(new Error('Session check timeout')), 800);
+          setTimeout(() => reject(new Error('Session check timeout')), 500);
         });
 
         try {
@@ -385,9 +385,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             // Fetch profile in background with timeout
             const profileTimeoutPromise = new Promise<UserProfile | null>((resolve) => {
               setTimeout(() => {
-                console.warn('⏱️ Profile fetch timeout (1.5s)');
+                console.warn('⏱️ Profile fetch timeout (800ms)');
                 resolve(null);
-              }, 1500);
+              }, 800);
             });
 
             Promise.race([
@@ -450,11 +450,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     console.log(`🔐 [AuthContext] Starting sign in for: ${email}`);
 
     const hardTimeoutId = setTimeout(() => {
-      console.warn('⚠️ [AuthContext] Sign-in hard timeout (3s): forcing loading state clear');
+      console.warn('⚠️ [AuthContext] Sign-in hard timeout (2s): forcing loading state clear');
       if (mountedRef.current) {
         setLoading(false);
       }
-    }, 3000);
+    }, 2000);
 
     const { data, error } = await safeAuthOperation(async () => {
       console.log(`📝 [AuthContext] Calling supabase.auth.signInWithPassword for ${email}...`);
@@ -514,9 +514,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           // This ensures components render with correct role/email filtering
           const profileTimeoutPromise = new Promise<UserProfile | null>((resolve) => {
             setTimeout(() => {
-              console.warn('⏱️ Profile fetch timeout during sign in (2s)');
+              console.warn('⏱️ Profile fetch timeout during sign in (1s)');
               resolve(null);
-            }, 2000); // 2 second timeout for sign in flow
+            }, 1000); // 1 second timeout for sign in flow
           });
 
           console.log('🔍 Starting profile fetch with 2s timeout...');


### PR DESCRIPTION
### Summary
This PR fixes an issue where protected pages (such as the LCL BOQ page) would incorrectly redirect unauthenticated users to the dashboard by adding a Supabase session fallback verification in `ProtectedRoute` and reducing auth initialization timeouts.

### Problem
The LCL BOQ page was failing to load for authenticated users — it would show an "authentication required" error and auto-redirect to the dashboard. The root cause was a race condition where the `AuthContext` loading state completed before the session was fully resolved, causing `ProtectedRoute` to incorrectly treat the user as unauthenticated.

### Solution
A direct Supabase session verification fallback was added to `ProtectedRoute`. If the auth context reports the user as unauthenticated after loading completes, the component now performs a secondary `supabase.auth.getSession()` check before blocking access. Auth initialization timeouts were also tightened to reduce the window for race conditions.

### Key Changes
- **`ProtectedRoute.tsx`**: Added `sessionVerified` and `verifyingSession` state; after context loading completes without authentication, a fallback `supabase.auth.getSession()` call is made to confirm the session before blocking access.
- **`ProtectedRoute.tsx`**: The auth block condition now requires both `!isAuthenticated` and `!sessionVerified` to be true before denying access.
- **`AuthContext.tsx`**: Reduced hard initialization timeout from 2000ms → 1500ms.
- **`AuthContext.tsx`**: Reduced session check timeout from 800ms → 500ms.
- **`AuthContext.tsx`**: Reduced profile fetch timeout from 1500ms → 800ms (init) and 2000ms → 1000ms (sign-in flow).
- **`AuthContext.tsx`**: Reduced sign-in hard timeout from 3000ms → 2000ms.


---

<a href="https://builder.io/app/projects/2333462329db483bb896/lime-spring-rbjasled"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://2333462329db483bb896-lime-spring-rbjasled_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=2333462329db483bb896&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 319`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2333462329db483bb896</projectId>-->
<!--<branchName>lime-spring-rbjasled</branchName>-->