### PR TITLE
Remove noisy toast notifications on app load

### DIFF
--- a/src/components/auth/EnhancedLogin.tsx
+++ b/src/components/auth/EnhancedLogin.tsx
@@ -22,12 +22,6 @@ export function EnhancedLogin() {
   const [showPassword, setShowPassword] = useState(false);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
 
-  useEffect(() => {
-    toast.success('Ready to sign in', {
-      description: 'Enter your credentials to access the system',
-      duration: 3000
-    });
-  }, []);
 
   const validateForm = () => {
     const errors: Record<string, string> = {};

--- a/src/pages/FixedBOQ.tsx
+++ b/src/pages/FixedBOQ.tsx
@@ -59,9 +59,6 @@ export default function FixedBOQ() {
         .order('sort_order', { ascending: true });
       if (error) throw error;
       setItems((data as FixedBOQItem[]) || []);
-      if ((data || []).length === 0) {
-        toast.info('No Fixed BOQ items found for this company');
-      }
     } catch (err) {
       console.warn('Failed to load fixed_boq_items:', err);
       toast.error('Failed to load Fixed BOQ items');


### PR DESCRIPTION
### Summary
Removes two unwanted toast notifications that were firing automatically on mount — one on the login page and one on the Fixed BOQ page.

### Problem
A "Ready to sign in" toast was popping up every time the app loaded on the login screen, and an info toast was appearing on the Fixed BOQ page whenever no items were found. These notifications were disruptive and were also causing misbehaviour on the normal BOQs and LCL BOQs pages.

### Solution
Removed the `useEffect`-triggered success toast from `EnhancedLogin` and removed the conditional info toast from the Fixed BOQ data-fetching logic.

### Key Changes
- **`EnhancedLogin.tsx`**: Deleted the `useEffect` that fired a `toast.success('Ready to sign in')` notification on component mount.
- **`FixedBOQ.tsx`**: Removed the `toast.info('No Fixed BOQ items found for this company')` call that triggered when the fetched data array was empty.


---

<a href="https://builder.io/app/projects/eda135af751a4ba3a02e/granite-summit-erjhbo7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://eda135af751a4ba3a02e-granite-summit-erjhbo7e_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=eda135af751a4ba3a02e&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 320`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>eda135af751a4ba3a02e</projectId>-->
<!--<branchName>granite-summit-erjhbo7e</branchName>-->