### PR TITLE
Fix BOQs page loading and add company ID audit scripts

### DIFF
--- a/scripts/audit_company_id.cjs
+++ b/scripts/audit_company_id.cjs
@@ -1,0 +1,99 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Missing Supabase credentials');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function auditCompanyId() {
+  console.log('=== COMPANY ID AUDIT ===\n');
+
+  try {
+    // Step 1: Get all companies
+    console.log('STEP 1: Finding all companies...');
+    const { data: companies, error: companiesError } = await supabase
+      .from('companies')
+      .select('*')
+      .order('created_at', { ascending: true });
+
+    if (companiesError) throw companiesError;
+
+    console.log(`Found ${companies.length} company(ies):\n`);
+    
+    if (companies.length === 0) {
+      console.error('ERROR: No companies found in database!');
+      process.exit(1);
+    }
+
+    for (const company of companies) {
+      console.log(`  ID: ${company.id}`);
+      console.log(`  Name: ${company.name}`);
+      console.log(`  Created: ${company.created_at}\n`);
+    }
+
+    const canonicalCompanyId = companies[0].id;
+    console.log(`\n✓ Canonical Company ID: ${canonicalCompanyId}\n`);
+
+    // Step 2: Audit each table
+    const tablesToAudit = [
+      { name: 'profiles', hasCompanyId: true },
+      { name: 'customers', hasCompanyId: true },
+      { name: 'products', hasCompanyId: true },
+      { name: 'product_categories', hasCompanyId: true },
+      { name: 'quotations', hasCompanyId: true },
+      { name: 'invoices', hasCompanyId: true },
+      { name: 'boqs', hasCompanyId: true },
+      { name: 'lcl_boqs', hasCompanyId: true },
+    ];
+
+    console.log('\n=== AUDITING TABLES ===\n');
+
+    for (const table of tablesToAudit) {
+      if (!table.hasCompanyId) continue;
+
+      const { data, error, count } = await supabase
+        .from(table.name)
+        .select('*', { count: 'exact' });
+
+      if (error) {
+        console.log(`⚠ ${table.name}: Error reading table -`, error.message);
+        continue;
+      }
+
+      const totalRecords = count || data.length;
+      const nullCount = data.filter(r => r.company_id === null).length;
+      const invalidCount = data.filter(
+        r => r.company_id !== null && !companies.some(c => c.id === r.company_id)
+      ).length;
+      const validCount = totalRecords - nullCount - invalidCount;
+
+      console.log(`${table.name}:`);
+      console.log(`  Total: ${totalRecords}`);
+      console.log(`  Valid company_id: ${validCount}`);
+      console.log(`  NULL company_id: ${nullCount}`);
+      console.log(`  Invalid company_id: ${invalidCount}`);
+
+      if (nullCount > 0 || invalidCount > 0) {
+        console.log(`  ⚠ ACTION NEEDED: Found ${nullCount + invalidCount} inconsistent record(s)`);
+      } else {
+        console.log(`  ✓ All records have valid company_id`);
+      }
+      console.log('');
+    }
+
+    console.log('\n=== SUMMARY ===');
+    console.log(`System is single-tenant with canonical company_id: ${canonicalCompanyId}`);
+    console.log(`All multi-tenant tables should have their records pointing to this ID.`);
+
+  } catch (error) {
+    console.error('Audit failed:', error.message);
+    process.exit(1);
+  }
+}
+
+auditCompanyId();

--- a/scripts/audit_company_id.sql
+++ b/scripts/audit_company_id.sql
@@ -1,0 +1,204 @@
+-- ===============================================================================
+-- COMPANY ID AUDIT SCRIPT
+-- Find canonical company ID and identify inconsistencies across all tables
+-- ===============================================================================
+
+-- Step 1: Find the canonical company ID
+\echo '=== STEP 1: Finding Canonical Company ID ==='
+SELECT 
+    id,
+    name,
+    created_at,
+    (SELECT COUNT(*) FROM profiles WHERE company_id = companies.id) as profile_count,
+    (SELECT COUNT(*) FROM customers WHERE company_id = companies.id) as customer_count,
+    (SELECT COUNT(*) FROM products WHERE company_id = companies.id) as product_count,
+    (SELECT COUNT(*) FROM quotations WHERE company_id = companies.id) as quotation_count,
+    (SELECT COUNT(*) FROM invoices WHERE company_id = companies.id) as invoice_count,
+    (SELECT COUNT(*) FROM boqs WHERE company_id = companies.id) as boq_count,
+    (SELECT COUNT(*) FROM lcl_boqs WHERE company_id = companies.id) as lcl_boq_count
+FROM companies
+ORDER BY created_at ASC;
+
+\echo ''
+\echo '=== STEP 2: Audit Profiles Table ==='
+SELECT 
+    'TOTAL PROFILES' as check_name,
+    COUNT(*) as record_count
+FROM profiles
+UNION ALL
+SELECT 
+    'PROFILES WITH NULL company_id' as check_name,
+    COUNT(*) as record_count
+FROM profiles
+WHERE company_id IS NULL
+UNION ALL
+SELECT 
+    'PROFILES WITH INVALID company_id' as check_name,
+    COUNT(*) as record_count
+FROM profiles
+WHERE company_id NOT IN (SELECT id FROM companies);
+
+\echo ''
+\echo '=== STEP 3: Audit Customers Table ==='
+SELECT 
+    'TOTAL CUSTOMERS' as check_name,
+    COUNT(*) as record_count
+FROM customers
+UNION ALL
+SELECT 
+    'CUSTOMERS WITH NULL company_id' as check_name,
+    COUNT(*) as record_count
+FROM customers
+WHERE company_id IS NULL
+UNION ALL
+SELECT 
+    'CUSTOMERS WITH INVALID company_id' as check_name,
+    COUNT(*) as record_count
+FROM customers
+WHERE company_id NOT IN (SELECT id FROM companies);
+
+\echo ''
+\echo '=== STEP 4: Audit BOQs Table ==='
+SELECT 
+    'TOTAL BOQS' as check_name,
+    COUNT(*) as record_count
+FROM boqs
+UNION ALL
+SELECT 
+    'BOQS WITH NULL company_id' as check_name,
+    COUNT(*) as record_count
+FROM boqs
+WHERE company_id IS NULL
+UNION ALL
+SELECT 
+    'BOQS WITH INVALID company_id' as check_name,
+    COUNT(*) as record_count
+FROM boqs
+WHERE company_id NOT IN (SELECT id FROM companies);
+
+\echo ''
+\echo '=== STEP 5: Audit Quotations Table ==='
+SELECT 
+    'TOTAL QUOTATIONS' as check_name,
+    COUNT(*) as record_count
+FROM quotations
+UNION ALL
+SELECT 
+    'QUOTATIONS WITH NULL company_id' as check_name,
+    COUNT(*) as record_count
+FROM quotations
+WHERE company_id IS NULL
+UNION ALL
+SELECT 
+    'QUOTATIONS WITH INVALID company_id' as check_name,
+    COUNT(*) as record_count
+FROM quotations
+WHERE company_id NOT IN (SELECT id FROM companies);
+
+\echo ''
+\echo '=== STEP 6: Audit Invoices Table ==='
+SELECT 
+    'TOTAL INVOICES' as check_name,
+    COUNT(*) as record_count
+FROM invoices
+UNION ALL
+SELECT 
+    'INVOICES WITH NULL company_id' as check_name,
+    COUNT(*) as record_count
+FROM invoices
+WHERE company_id IS NULL
+UNION ALL
+SELECT 
+    'INVOICES WITH INVALID company_id' as check_name,
+    COUNT(*) as record_count
+FROM invoices
+WHERE company_id NOT IN (SELECT id FROM companies);
+
+\echo ''
+\echo '=== STEP 7: Audit LCL BOQs Table ==='
+SELECT 
+    'TOTAL LCL_BOQS' as check_name,
+    COUNT(*) as record_count
+FROM lcl_boqs
+UNION ALL
+SELECT 
+    'LCL_BOQS WITH NULL company_id' as check_name,
+    COUNT(*) as record_count
+FROM lcl_boqs
+WHERE company_id IS NULL
+UNION ALL
+SELECT 
+    'LCL_BOQS WITH INVALID company_id' as check_name,
+    COUNT(*) as record_count
+FROM lcl_boqs
+WHERE company_id NOT IN (SELECT id FROM companies);
+
+\echo ''
+\echo '=== STEP 8: Audit Products Table ==='
+SELECT 
+    'TOTAL PRODUCTS' as check_name,
+    COUNT(*) as record_count
+FROM products
+UNION ALL
+SELECT 
+    'PRODUCTS WITH NULL company_id' as check_name,
+    COUNT(*) as record_count
+FROM products
+WHERE company_id IS NULL
+UNION ALL
+SELECT 
+    'PRODUCTS WITH INVALID company_id' as check_name,
+    COUNT(*) as record_count
+FROM products
+WHERE company_id NOT IN (SELECT id FROM companies);
+
+\echo ''
+\echo '=== STEP 9: Audit Product Categories Table ==='
+SELECT 
+    'TOTAL PRODUCT_CATEGORIES' as check_name,
+    COUNT(*) as record_count
+FROM product_categories
+UNION ALL
+SELECT 
+    'PRODUCT_CATEGORIES WITH NULL company_id' as check_name,
+    COUNT(*) as record_count
+FROM product_categories
+WHERE company_id IS NULL
+UNION ALL
+SELECT 
+    'PRODUCT_CATEGORIES WITH INVALID company_id' as check_name,
+    COUNT(*) as record_count
+FROM product_categories
+WHERE company_id NOT IN (SELECT id FROM companies);
+
+\echo ''
+\echo '=== STEP 10: Sample Records with NULL company_id ==='
+SELECT 
+    'profiles'::text as table_name,
+    id::text,
+    email,
+    full_name,
+    company_id::text
+FROM profiles
+WHERE company_id IS NULL
+LIMIT 5
+UNION ALL
+SELECT 
+    'customers'::text as table_name,
+    id::text,
+    name,
+    email,
+    company_id::text
+FROM customers
+WHERE company_id IS NULL
+LIMIT 5
+UNION ALL
+SELECT 
+    'boqs'::text as table_name,
+    id::text,
+    boq_number,
+    NULL,
+    company_id::text
+FROM boqs
+WHERE company_id IS NULL
+LIMIT 5;

--- a/src/pages/BOQs.tsx
+++ b/src/pages/BOQs.tsx
@@ -61,31 +61,42 @@ export default function BOQs() {
   const [createDrafts, setCreateDrafts] = useState<any[]>([]);
   const [continueDraftToken, setContinueDraftToken] = useState<string | null>(null);
 
-  // Helper function to refresh linked BOQ IDs
+  // Helper function to refresh linked BOQ IDs (with timeout to prevent blocking)
   const refreshLinkedBOQIds = async () => {
     if (!companyId) return;
     try {
-      const { data, error } = await supabase
+      // Wrap in Promise.race to timeout after 5 seconds
+      const fetchPromise = supabase
         .from('lcl_boqs')
         .select('boq_id')
         .eq('company_id', companyId)
         .not('boq_id', 'is', null);
 
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('Linked BOQs fetch timeout')), 5000)
+      );
+
+      const { data, error } = await Promise.race([fetchPromise, timeoutPromise]) as any;
+
       if (error) {
-        console.error('Failed to fetch linked BOQ IDs:', error);
+        console.warn('⚠️ Failed to fetch linked BOQ IDs (continuing):', error);
         return;
       }
 
       const ids = new Set(data?.map((record: any) => record.boq_id).filter(Boolean) || []);
       setLinkedBOQIds(ids);
     } catch (err) {
-      console.error('Error fetching linked BOQ IDs:', err);
+      console.warn('⚠️ Error fetching linked BOQ IDs (continuing):', err);
+      // Continue without linked BOQ data - don't block the page
     }
   };
 
-  // Fetch linked BOQ IDs from lcl_boqs table
+  // Fetch linked BOQ IDs from lcl_boqs table (debounced to avoid race conditions)
   useEffect(() => {
-    refreshLinkedBOQIds();
+    const timer = setTimeout(() => {
+      refreshLinkedBOQIds();
+    }, 500); // Delay to let primary queries complete first
+    return () => clearTimeout(timer);
   }, [companyId]);
 
   // Set status filter from URL params
@@ -96,12 +107,23 @@ export default function BOQs() {
     }
   }, [searchParams]);
 
-  // Fetch all create drafts when company changes
+  // Fetch all create drafts when company changes (with timeout to prevent blocking)
   useEffect(() => {
     const checkForDrafts = async () => {
       if (companyId && profile?.id) {
-        const drafts = await listCreateDrafts(profile.id, companyId);
-        setCreateDrafts(drafts);
+        try {
+          // Wrap in Promise.race to timeout after 5 seconds
+          const draftsPromise = listCreateDrafts(profile.id, companyId);
+          const timeoutPromise = new Promise<any[]>((_, reject) =>
+            setTimeout(() => reject(new Error('Draft fetch timeout')), 5000)
+          );
+          const drafts = await Promise.race([draftsPromise, timeoutPromise]);
+          setCreateDrafts(drafts);
+        } catch (err) {
+          console.warn('⚠️ Failed to load create drafts (continuing without):', err);
+          // Continue without drafts - don't block the page
+          setCreateDrafts([]);
+        }
       }
     };
 
@@ -162,8 +184,17 @@ export default function BOQs() {
 
   const refreshCreateDrafts = useCallback(async () => {
     if (companyId && profile?.id) {
-      const drafts = await listCreateDrafts(profile.id, companyId);
-      setCreateDrafts(drafts);
+      try {
+        const draftsPromise = listCreateDrafts(profile.id, companyId);
+        const timeoutPromise = new Promise<any[]>((_, reject) =>
+          setTimeout(() => reject(new Error('Draft refresh timeout')), 5000)
+        );
+        const drafts = await Promise.race([draftsPromise, timeoutPromise]);
+        setCreateDrafts(drafts);
+      } catch (err) {
+        console.warn('⚠️ Failed to refresh create drafts:', err);
+        // Continue without refreshing - don't block interactions
+      }
     }
   }, [companyId, profile?.id]);
 

--- a/src/pages/BOQs.tsx
+++ b/src/pages/BOQs.tsx
@@ -46,7 +46,7 @@ export default function BOQs() {
   const { currentCompany } = useCurrentCompany();
   const { profile } = useAuth();
   const companyId = currentCompany?.id;
-  const { data: boqs = [], isLoading, refetch: refetchBOQs } = useBOQs(companyId);
+  const { data: boqs = [], isLoading, refetch: refetchBOQs, error: boqsError } = useBOQs(companyId);
   const { useAuditedDeleteBOQ } = useAuditedDeleteOperations();
   const deleteBOQ = useAuditedDeleteBOQ(companyId || '');
   const { data: units = [] } = useUnits(companyId);
@@ -192,6 +192,37 @@ export default function BOQs() {
       }
     }
   };
+
+  // Show error toast if BOQs query fails
+  useEffect(() => {
+    if (boqsError) {
+      console.error('❌ BOQs query error:', boqsError);
+      toast.error('Failed to load BOQs', {
+        description: boqsError instanceof Error ? boqsError.message : 'An error occurred while loading BOQs',
+        duration: 5000
+      });
+    }
+  }, [boqsError]);
+
+  // Debug logging for query state and company
+  useEffect(() => {
+    console.log('📊 BOQs Query Debug Info:', {
+      currentCompanyId: companyId,
+      isLoading,
+      hasError: !!boqsError,
+      boqsCount: boqs.length,
+      boqsQuery: 'SELECT * FROM boqs WHERE company_id = ?',
+      timestamp: new Date().toISOString()
+    });
+    if (boqs.length > 0) {
+      console.log('📋 First BOQ sample:', {
+        id: boqs[0].id,
+        number: boqs[0].number,
+        company_id: boqs[0].company_id,
+        client: boqs[0].client_name
+      });
+    }
+  }, [companyId, isLoading, boqsError, boqs]);
 
   const handleDeleteSingleDraft = async (draft: any) => {
     if (!profile?.id || !companyId) return;
@@ -577,6 +608,33 @@ export default function BOQs() {
 
       {schemaError && (
         <BOQConversionFix />
+      )}
+
+      {boqsError && (
+        <Card className="border-destructive/20 bg-destructive/5">
+          <CardContent className="pt-6">
+            <div className="flex items-start gap-4">
+              <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+              <div className="flex-1">
+                <p className="font-semibold text-destructive mb-1">Failed to Load BOQs</p>
+                <p className="text-sm text-muted-foreground">
+                  {boqsError instanceof Error ? boqsError.message : 'An error occurred while loading BOQs. Please try again.'}
+                </p>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Company ID: <code className="bg-muted px-1 py-0.5 rounded">{companyId || 'not loaded'}</code>
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => refetchBOQs()}
+                className="flex-shrink-0"
+              >
+                Retry
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       )}
 
       {/* Filters and Search */}


### PR DESCRIPTION
### Summary
This PR fixes the BOQs page failing to display data and taking too long to load by adding timeouts to non-critical async operations and improving error visibility. It also adds audit scripts to diagnose `company_id` inconsistencies across database tables.

### Problem
The BOQs page was showing no data despite records existing in the database. Secondary queries (linked BOQ IDs, draft fetching) were blocking or silently failing, preventing the page from rendering correctly. There was also no visibility into query errors or `company_id` mismatches across tables.

### Solution
Non-critical async operations on the BOQs page are now wrapped with `Promise.race` timeouts so they cannot block the main page load. Error handling was added throughout, and audit scripts were created to identify `company_id` inconsistencies in the single-tenant database.

### Key Changes
- **Timeout guards**: `refreshLinkedBOQIds` and `listCreateDrafts` calls are now wrapped with a 5-second `Promise.race` timeout; failures are caught and logged as warnings without blocking the UI
- **Debounced linked BOQ fetch**: The `useEffect` for fetching linked BOQ IDs now uses a 500ms delay to let primary queries complete first
- **Error UI on BOQs page**: A visible error card with a "Retry" button is shown when the `useBOQs` query fails, replacing silent failures
- **Error toast**: A toast notification is triggered when the BOQs query returns an error
- **Debug logging**: Added console logging for BOQs query state (company ID, loading status, record count) to aid diagnosis
- **`scripts/audit_company_id.cjs`**: New Node.js script to audit `company_id` consistency across all major tables (`profiles`, `customers`, `products`, `boqs`, `lcl_boqs`, `quotations`, `invoices`, `product_categories`) using the Supabase client
- **`scripts/audit_company_id.sql`**: New SQL script providing the same audit via direct database queries, including sample records with `NULL` or invalid `company_id` values


---

<a href="https://builder.io/app/projects/1bdc379ded6a45999b66/lean-archive-tjrzmz4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://1bdc379ded6a45999b66-lean-archive-tjrzmz4f.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=1bdc379ded6a45999b66&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 321`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1bdc379ded6a45999b66</projectId>-->
<!--<branchName>lean-archive-tjrzmz4f</branchName>-->