### PR TITLE
Fix missing terms and conditions in BOQ PDFs

### DIFF
--- a/src/components/boq/EditBOQModal.tsx
+++ b/src/components/boq/EditBOQModal.tsx
@@ -330,7 +330,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess, company }: Ed
           setContractor(dataToUse.contractor || boqData.contractor || '');
           setNotes(boqData.notes || '');
 
-          const termsToUse = dataToUse.termsAndConditions || '';
+          const termsToUse = dataToUse.termsAndConditions || currentCompany?.default_terms_and_conditions || '';
           setTermsAndConditions(termsToUse);
           const showCalcValues = dataToUse.showCalculatedValuesInTerms || false;
           setShowCalculatedValuesInTerms(showCalcValues);

--- a/src/components/boq/EditBOQModal.tsx
+++ b/src/components/boq/EditBOQModal.tsx
@@ -330,7 +330,7 @@ export function EditBOQModal({ open, onOpenChange, boq, onSuccess, company }: Ed
           setContractor(dataToUse.contractor || boqData.contractor || '');
           setNotes(boqData.notes || '');
 
-          const termsToUse = dataToUse.termsAndConditions || currentCompany?.default_terms_and_conditions || '';
+          const termsToUse = (dataToUse.terms_and_conditions || dataToUse.termsAndConditions) || currentCompany?.default_terms_and_conditions || '';
           setTermsAndConditions(termsToUse);
           const showCalcValues = dataToUse.showCalculatedValuesInTerms || false;
           setShowCalculatedValuesInTerms(showCalcValues);

--- a/src/pages/BOQs.tsx
+++ b/src/pages/BOQs.tsx
@@ -388,6 +388,7 @@ export default function BOQs() {
         header_image: currentCompany.header_image || undefined,
         stamp_image: currentCompany.stamp_image || undefined,
         company_services: currentCompany.company_services || undefined,
+        default_terms_and_conditions: currentCompany.default_terms_and_conditions || undefined,
       } : undefined, options);
       const suffix = options?.customTitle ? ` (${options.customTitle})` : '';
       toast.success(`BOQ ${boq.number} PDF downloaded${suffix}`);

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -1363,12 +1363,19 @@ export const generatePDF = async (data: DocumentData) => {
 
       <!-- Page 2: Terms and Conditions -->
       <div class="terms-page page">
-        <!-- Terms Section (only shown if terms are provided) -->
+        <!-- Terms Section (shown if provided or use company default) -->
         ${(data.terms_and_conditions && data.terms_and_conditions.trim()) ? `
         <div style="margin-bottom: 8px;">
           <h3 style="font-size: 13px; font-weight: bold; margin-bottom: 4px; margin-top: 0; text-transform: uppercase;">Terms;</h3>
           <div style="font-size: 11px; line-height: 1.4; margin: 0; padding: 0; color: #000;">
             ${parseAndRenderTerms(data.terms_and_conditions, grandTotalForBOQ, data.showCalculatedValuesInTerms !== false, formatCurrency)}
+          </div>
+        </div>
+        ` : (company && company.default_terms_and_conditions && company.default_terms_and_conditions.trim()) ? `
+        <div style="margin-bottom: 8px;">
+          <h3 style="font-size: 13px; font-weight: bold; margin-bottom: 4px; margin-top: 0; text-transform: uppercase;">Terms;</h3>
+          <div style="font-size: 11px; line-height: 1.4; margin: 0; padding: 0; color: #000;">
+            ${parseAndRenderTerms(company.default_terms_and_conditions, grandTotalForBOQ, data.showCalculatedValuesInTerms !== false, formatCurrency)}
           </div>
         </div>
         ` : ''}


### PR DESCRIPTION
### Summary
Ensures terms and conditions always appear in BOQ PDFs by falling back to the company's default terms when no BOQ-specific terms are set.

### Problem
Terms and conditions were missing from some BOQ PDFs — the PDF would skip straight to the acceptance section. This happened because the PDF generator and the edit modal only checked for BOQ-level terms and had no fallback to the company's default terms and conditions.

### Solution
Added a fallback chain so that if a BOQ does not have its own terms and conditions, the company's `default_terms_and_conditions` is used instead — both in the PDF generator and in the Edit BOQ modal.

### Key Changes
- **`pdfGenerator.ts`**: Added a secondary condition in the terms section template to render `company.default_terms_and_conditions` when no BOQ-specific terms are present.
- **`BOQs.tsx`**: Passes `default_terms_and_conditions` from the current company into the PDF generation options so it is available to the generator.
- **`EditBOQModal.tsx`**: Updated terms resolution to check `terms_and_conditions` (snake_case), then `termsAndConditions` (camelCase), then fall back to `currentCompany?.default_terms_and_conditions` when populating the modal.

---

<a href="https://builder.io/app/projects/127f1db40ce04daab816/core-nest-8oiffltq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://127f1db40ce04daab816-core-nest-8oiffltq.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=127f1db40ce04daab816&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 332`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>127f1db40ce04daab816</projectId>-->
<!--<branchName>core-nest-8oiffltq</branchName>-->