### PR TITLE
Show per-invoice payment allocations in statements and PDFs

### DIFF
--- a/src/pages/reports/StatementOfAccounts.tsx
+++ b/src/pages/reports/StatementOfAccounts.tsx
@@ -60,7 +60,39 @@ const computeCustomerStatements = (customers: any[], invoices: any[], payments: 
 
     const overdueAmount = days30 + days60 + days90;
 
-    // Build transactions array
+    const invoiceNumbers = new Map(customerInvoices.map(invoice => [invoice.id, invoice.invoice_number]));
+    const paymentTransactions = customerPayments.flatMap(payment => {
+      const allocations = payment.payment_allocations || [];
+      const allocatedAmount = allocations.reduce((total: number, allocation: any) => total + Number(allocation.allocated_amount || allocation.amount_allocated || 0), 0);
+      const allocatedTransactions = allocations
+        .filter((allocation: any) => allocation.invoice_id && invoiceNumbers.has(allocation.invoice_id))
+        .map((allocation: any) => {
+          const invoiceNumber = invoiceNumbers.get(allocation.invoice_id);
+          return {
+            date: payment.payment_date,
+            type: 'Payment',
+            reference: `${payment.payment_number} · ${invoiceNumber}`,
+            description: `Payment applied to invoice ${invoiceNumber}`,
+            debit: 0,
+            credit: Number(allocation.allocated_amount || allocation.amount_allocated || 0),
+            balance: 0
+          };
+        });
+      const unallocatedAmount = Math.max(0, Number(payment.amount || 0) - allocatedAmount);
+
+      return unallocatedAmount > 0
+        ? [...allocatedTransactions, {
+            date: payment.payment_date,
+            type: 'Payment',
+            reference: payment.payment_number,
+            description: 'Unallocated payment',
+            debit: 0,
+            credit: unallocatedAmount,
+            balance: 0
+          }]
+        : allocatedTransactions;
+    });
+
     const allTransactions = [
       ...customerInvoices.map(inv => ({
         date: inv.invoice_date,
@@ -69,17 +101,9 @@ const computeCustomerStatements = (customers: any[], invoices: any[], payments: 
         description: `Invoice - ${inv.invoice_number}`,
         debit: Number(inv.total_amount) || 0,
         credit: 0,
-        balance: 0 // Will be calculated
+        balance: 0
       })),
-      ...customerPayments.map(pay => ({
-        date: pay.payment_date,
-        type: 'Payment',
-        reference: pay.payment_number,
-        description: `Payment - ${pay.payment_method || 'Cash'}`,
-        debit: 0,
-        credit: Number(pay.amount) || 0,
-        balance: 0 // Will be calculated
-      }))
+      ...paymentTransactions
     ];
 
     // Sort by date and calculate running balance

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -473,6 +473,12 @@ export interface DocumentData {
   total_amount: number;
   paid_amount?: number;
   balance_due?: number;
+  payment_transactions?: Array<{
+    payment_number: string;
+    payment_date: string;
+    payment_method: string;
+    amount: number;
+  }>;
   notes?: string;
   terms_and_conditions?: string;
   showCalculatedValuesInTerms?: boolean; // Whether to show calculated values (e.g., "50% (KES 50,000)") in terms
@@ -3588,6 +3594,32 @@ export const generatePDF = async (data: DocumentData) => {
         </div>
         ` : ''}
 
+        ${(data.type === 'invoice' || data.type === 'proforma') && data.payment_transactions && data.payment_transactions.length > 0 ? `
+        <div class="payment-section" style="margin-top: 18px; border-top: 1px solid #d1d5db; padding-top: 12px;">
+          <h3 style="margin: 0 0 8px; font-size: 14px;">Payment Transaction History</h3>
+          <table class="items-table">
+            <thead>
+              <tr>
+                <th style="width: 24%;">Date</th>
+                <th style="width: 26%;">Payment Number</th>
+                <th style="width: 25%;">Method</th>
+                <th style="width: 25%;">Amount Applied</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${data.payment_transactions.map(transaction => `
+                <tr>
+                  <td>${formatDate(transaction.payment_date)}</td>
+                  <td>${transaction.payment_number}</td>
+                  <td>${transaction.payment_method.replace(/_/g, ' ')}</td>
+                  <td class="amount-cell">${formatCurrency(transaction.amount)}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+        ` : ''}
+
         <!-- Payment Details Section (for receipts) -->
         ${data.type === 'receipt' ? `
         <div class="payment-section" style="margin-top: 8px; border-top: 2px solid #000; padding-top: 8px;">
@@ -4178,9 +4210,40 @@ export const generateCustomerStatementPDF = async (customer: any, invoices: any[
     return daysOverdue > 90 && (inv.total_amount - (inv.paid_amount || 0)) > 0;
   }).reduce((sum, inv) => sum + (inv.total_amount - (inv.paid_amount || 0)), 0);
 
-  // Create all transactions (invoices and payments) with running balance
+  const invoiceNumbers = new Map(invoices.map(invoice => [invoice.id, invoice.invoice_number]));
+  const paymentTransactions = payments.flatMap(payment => {
+    const allocations = payment.payment_allocations || [];
+    const allocatedAmount = allocations.reduce((total: number, allocation: any) => total + Number(allocation.allocated_amount || allocation.amount_allocated || 0), 0);
+    const allocatedTransactions = allocations
+      .filter((allocation: any) => allocation.invoice_id && invoiceNumbers.has(allocation.invoice_id))
+      .map((allocation: any) => {
+        const invoiceNumber = invoiceNumbers.get(allocation.invoice_id);
+        return {
+          date: payment.payment_date,
+          type: 'payment',
+          reference: `${payment.payment_number || payment.id || 'PMT'} · ${invoiceNumber}`,
+          description: `Payment applied to invoice ${invoiceNumber}`,
+          debit: 0,
+          credit: Number(allocation.allocated_amount || allocation.amount_allocated || 0),
+          due_date: null
+        };
+      });
+    const unallocatedAmount = Math.max(0, Number(payment.amount || 0) - allocatedAmount);
+
+    return unallocatedAmount > 0
+      ? [...allocatedTransactions, {
+          date: payment.payment_date,
+          type: 'payment',
+          reference: payment.payment_number || payment.id || 'PMT',
+          description: 'Unallocated payment',
+          debit: 0,
+          credit: unallocatedAmount,
+          due_date: null
+        }]
+      : allocatedTransactions;
+  });
+
   const allTransactions = [
-    // Add all invoices as debits
     ...invoices.map(inv => ({
       date: inv.invoice_date,
       type: 'invoice',
@@ -4190,16 +4253,7 @@ export const generateCustomerStatementPDF = async (customer: any, invoices: any[
       credit: 0,
       due_date: inv.due_date
     })),
-    // Add all payments as credits
-    ...payments.map(pay => ({
-      date: pay.payment_date,
-      type: 'payment',
-      reference: pay.payment_number || pay.id || 'PMT',
-      description: `Payment - ${pay.method || 'Cash'}`,
-      debit: 0,
-      credit: pay.amount || 0,
-      due_date: null
-    }))
+    ...paymentTransactions
   ];
 
   // Sort by date


### PR DESCRIPTION
### Summary
Updates customer statement generation and PDF exports to break down payments by the invoices they were allocated to, instead of showing a single lump-sum payment entry.

### Problem
Previously, payments in the Statement of Accounts and PDF customer statements were listed as a single generic transaction (e.g. "Payment - Cash") without indicating which invoice(s) the payment was applied to. This made it hard to reconcile which invoices were actually settled by a given payment, and the dashboard/statement summaries could look misleading as a result.

### Solution
Payments are now expanded into their individual `payment_allocations`, generating one transaction line per invoice allocation (with a reference to the invoice number), plus a separate "Unallocated payment" line for any remaining unallocated amount. This logic is applied consistently in both the in-app Statement of Accounts computation and the PDF statement generator.

### Key Changes
- `src/pages/reports/StatementOfAccounts.tsx`: Replaced the single payment-per-transaction mapping with a `flatMap` over `payment_allocations`, producing per-invoice payment transactions plus an "Unallocated payment" entry when applicable.
- `src/utils/pdfGenerator.ts`:
  - Applied the same allocation-based transaction breakdown in `generateCustomerStatementPDF`.
  - Added a new `payment_transactions` field to `DocumentData` and rendered a "Payment Transaction History" table on invoice/proforma PDFs showing payment number, date, method, and amount applied.


---

<a href="https://builder.io/app/projects/2498ab0115a9434496b9/legend-prize-knkg2ykq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://2498ab0115a9434496b9-legend-prize-knkg2ykq.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=2498ab0115a9434496b9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 336`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2498ab0115a9434496b9</projectId>-->
<!--<branchName>legend-prize-knkg2ykq</branchName>-->