### PR TITLE
Add payment reference number to invoice payments display

### DIFF
--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -984,6 +984,7 @@ Website:`;
                                   <TableHead className="text-xs">Payment Number</TableHead>
                                   <TableHead className="text-xs">Payment Date</TableHead>
                                   <TableHead className="text-xs">Payment Method</TableHead>
+                                  <TableHead className="text-xs">Reference Number</TableHead>
                                   <TableHead className="text-xs">Amount Allocated</TableHead>
                                 </TableRow>
                               </TableHeader>
@@ -993,6 +994,7 @@ Website:`;
                                     <TableCell>{alloc.payments?.payment_number || 'N/A'}</TableCell>
                                     <TableCell>{alloc.payments?.payment_date ? new Date(alloc.payments.payment_date).toLocaleDateString() : 'N/A'}</TableCell>
                                     <TableCell className="capitalize">{(alloc.payments?.payment_method || 'N/A').replace('_', ' ')}</TableCell>
+                                    <TableCell>{alloc.payments?.reference_number || 'N/A'}</TableCell>
                                     <TableCell className="text-success font-medium">{formatCurrency(alloc.amount_allocated || 0, invoice.currency || 'KES')}</TableCell>
                                   </TableRow>
                                 ))}

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -477,6 +477,7 @@ export interface DocumentData {
     payment_number: string;
     payment_date: string;
     payment_method: string;
+    reference_number?: string;
     amount: number;
   }>;
   notes?: string;
@@ -3600,10 +3601,11 @@ export const generatePDF = async (data: DocumentData) => {
           <table class="items-table">
             <thead>
               <tr>
-                <th style="width: 24%;">Date</th>
-                <th style="width: 26%;">Payment Number</th>
-                <th style="width: 25%;">Method</th>
-                <th style="width: 25%;">Amount Applied</th>
+                <th style="width: 20%;">Date</th>
+                <th style="width: 22%;">Payment Number</th>
+                <th style="width: 18%;">Method</th>
+                <th style="width: 20%;">Reference</th>
+                <th style="width: 20%;">Amount Applied</th>
               </tr>
             </thead>
             <tbody>
@@ -3612,6 +3614,7 @@ export const generatePDF = async (data: DocumentData) => {
                   <td>${formatDate(transaction.payment_date)}</td>
                   <td>${transaction.payment_number}</td>
                   <td>${transaction.payment_method.replace(/_/g, ' ')}</td>
+                  <td>${transaction.reference_number || '-'}</td>
                   <td class="amount-cell">${formatCurrency(transaction.amount)}</td>
                 </tr>
               `).join('')}
@@ -3904,7 +3907,8 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
           payments(
             payment_number,
             payment_date,
-            payment_method
+            payment_method,
+            reference_number
           )
         `)
         .eq('invoice_id', invoice.id)
@@ -3917,6 +3921,7 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
           payment_number: alloc.payments?.payment_number || 'N/A',
           payment_date: alloc.payments?.payment_date || '',
           payment_method: alloc.payments?.payment_method || '',
+          reference_number: alloc.payments?.reference_number || '',
           amount: alloc.amount_allocated || 0
         }));
         console.log('✅ Payment allocations fetched:', paymentTransactions.length);


### PR DESCRIPTION
### Summary
Adds the payment reference number column to the related payments table on the Invoices list page and to the generated invoice PDF.

### Problem
When viewing related payments for an invoice, users could see payment number, date, method, and amount, but not the payment reference number, making it harder to reconcile payments with external records.

### Solution
Extended the payment allocations query and display components to fetch and show `reference_number` alongside existing payment details, in both the invoices UI table and the PDF payment breakdown.

### Key Changes
- **`src/pages/Invoices.tsx`**: Added a "Reference Number" column to the related payments table, displaying `alloc.payments?.reference_number` or "N/A".
- **`src/utils/pdfGenerator.ts`**:
  - Added optional `reference_number` field to the `DocumentData` payment transactions type.
  - Updated the PDF payments table to include a "Reference" column, adjusting column widths accordingly.
  - Updated the Supabase query in `downloadInvoicePDF` to fetch `reference_number` from the `payments` relation.
  - Mapped `reference_number` into the `paymentTransactions` array used to render the PDF.


---

<a href="https://builder.io/app/projects/a6c6d7e486eb46eb8ef1/key-gateway-350foj5p"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://a6c6d7e486eb46eb8ef1-key-gateway-350foj5p.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=a6c6d7e486eb46eb8ef1&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 337`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a6c6d7e486eb46eb8ef1</projectId>-->
<!--<branchName>key-gateway-350foj5p</branchName>-->