### PR TITLE
Fix invoice PDF missing payment transaction history

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -810,6 +810,10 @@ export const generatePDF = async (data: DocumentData) => {
   console.log('📋 Items count:', data.items?.length || 0);
   console.log('📑 Sections count:', data.sections?.length || 0);
   console.log('💰 Total amount:', data.total_amount);
+  console.log('💳 Payment transactions:', {
+    count: data.payment_transactions?.length || 0,
+    transactions: data.payment_transactions || []
+  });
   console.log('[generatePDF] ℹ️ Processing document with flags:', JSON.stringify({
     isLCLBOQ: data.isLCLBOQ,
     type: data.type,
@@ -3878,6 +3882,7 @@ export const generatePDF = async (data: DocumentData) => {
 // Specific function for invoice PDF generation
 export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' | 'PROFORMA' = 'INVOICE', company?: CompanyDetails, companyId?: string) => {
   console.log('🎯 downloadInvoicePDF called for:', invoice.invoice_number);
+  console.log('🆔 Invoice ID for payment allocations:', invoice.id);
   console.log('📊 Raw invoice_items count:', invoice.invoice_items?.length || 0);
   console.log('📊 Raw invoice_items:', invoice.invoice_items);
 
@@ -3896,9 +3901,27 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
   }
 
   // Fetch payment allocations for this invoice to include in PDF
-  let paymentTransactions: any[] = [];
+  const mapPaymentTransactions = (allocations: any[] = []) => allocations.map((allocation) => {
+    const payment = Array.isArray(allocation.payments) ? allocation.payments[0] : allocation.payments;
+
+    return {
+      payment_number: payment?.payment_number || 'N/A',
+      payment_date: payment?.payment_date || '',
+      payment_method: payment?.payment_method || 'N/A',
+      reference_number: payment?.reference_number || '',
+      amount: Number(allocation.amount_allocated || 0)
+    };
+  });
+
+  let paymentTransactions = mapPaymentTransactions(invoice.payment_allocations);
+  console.log('💳 Payment allocations supplied with invoice:', {
+    count: invoice.payment_allocations?.length || 0,
+    transactions: paymentTransactions
+  });
+
   if (invoice.id) {
     try {
+      console.log('🔎 Fetching payment allocations for invoice:', invoice.id);
       const { data: allocations, error } = await supabase
         .from('payment_allocations')
         .select(`
@@ -3914,22 +3937,22 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
         .eq('invoice_id', invoice.id)
         .order('created_at', { ascending: true });
 
+      console.log('💳 Payment allocations query result:', { allocations, error });
+
       if (error) {
-        console.warn('⚠️ Failed to fetch payment allocations (non-fatal):', error);
-      } else if (allocations && allocations.length > 0) {
-        paymentTransactions = allocations.map(alloc => ({
-          payment_number: alloc.payments?.payment_number || 'N/A',
-          payment_date: alloc.payments?.payment_date || '',
-          payment_method: alloc.payments?.payment_method || '',
-          reference_number: alloc.payments?.reference_number || '',
-          amount: alloc.amount_allocated || 0
-        }));
-        console.log('✅ Payment allocations fetched:', paymentTransactions.length);
+        console.warn('⚠️ Failed to fetch payment allocations; using invoice data when available:', error);
+      } else {
+        paymentTransactions = mapPaymentTransactions(allocations || []);
+        console.log('✅ Payment transactions mapped from query:', paymentTransactions);
       }
     } catch (err) {
-      console.warn('⚠️ Unexpected error fetching payment allocations (non-fatal):', err);
+      console.warn('⚠️ Unexpected error fetching payment allocations; using invoice data when available:', err);
     }
+  } else {
+    console.warn('⚠️ Invoice has no ID; using payment allocations supplied with the invoice.');
   }
+
+  console.log('💳 Final payment transactions for PDF:', paymentTransactions);
 
   const items = invoice.invoice_items?.map((item: any) => {
     const quantity = Number(item.quantity || 0);
@@ -4058,6 +4081,7 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
     };
   }
 
+  console.log('📄 Invoice PDF document data payment transactions:', documentData.payment_transactions);
   return generatePDF(documentData);
 };
 


### PR DESCRIPTION
### Summary
Fixes invoice PDF generation so payment transaction history is reliably captured and included, using invoice-supplied allocations as a fallback and adding detailed logging to trace data flow.

### Problem
Invoice PDFs were not displaying the "Payment Transaction History" section even though payments existed in the database and rendered correctly elsewhere. There was no visibility into whether the payment allocations query was returning data or whether `payment_transactions` was actually populated before being passed to `generatePDF()`.

### Solution
Added a shared mapping function for payment allocations that is used both for allocations already attached to the invoice object and for allocations fetched via Supabase, so a fallback exists if the query fails or returns nothing. Extensive console logging was added throughout `downloadInvoicePDF()` and `generatePDF()` to trace invoice ID, query results, and the final payment transactions passed into the document data.

### Key Changes
- Added `mapPaymentTransactions` helper in `src/utils/pdfGenerator.ts` to consistently map payment allocation records (from either the invoice object or a fresh query) into the PDF's expected transaction shape.
- `paymentTransactions` now initializes from `invoice.payment_allocations` before attempting the Supabase fetch, providing a fallback when the invoice ID is missing or the query fails.
- On successful query, transactions are remapped from the fetched allocations using the same helper for consistency.
- Added logging for: invoice ID used for the query, query result/error, mapped transactions from invoice data, mapped transactions from the query, and the final `payment_transactions` value in the document data.
- Added a warning log when an invoice has no ID, indicating that invoice-supplied allocations will be used instead.
- Added a log of `payment_transactions` count/content at the start of `generatePDF()`.


---

<a href="https://builder.io/app/projects/5f4519d1ed7442a4be37/nebula-realm-alc1koyn"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://5f4519d1ed7442a4be37-nebula-realm-alc1koyn.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=5f4519d1ed7442a4be37&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 338`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5f4519d1ed7442a4be37</projectId>-->
<!--<branchName>nebula-realm-alc1koyn</branchName>-->