### PR TITLE
Fix permission checks with per-user overrides

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -22,7 +22,7 @@ export function ProtectedRoute({
   allowedRoles,
   requiredFeature,
 }: ProtectedRouteProps) {
-  const { isAuthenticated, loading, profile } = useAuth();
+  const { isAuthenticated, loading, profile, permissions } = useAuth();
   const [sessionVerified, setSessionVerified] = useState(false);
   const [verifyingSession, setVerifyingSession] = useState(false);
 
@@ -98,7 +98,7 @@ export function ProtectedRoute({
     );
   }
 
-  if (requiredFeature && role && !hasFeature(role, requiredFeature)) {
+  if (requiredFeature && !hasFeature(role, requiredFeature, permissions)) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <Card className="w-full max-w-md text-center">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -127,7 +127,7 @@ interface SidebarProps {
 export function Sidebar({ isMobile = false, isOpen = true, onClose = () => {} }: SidebarProps) {
   const location = useLocation();
   const { currentCompany } = useCurrentCompany();
-  const { profile } = useAuth();
+  const { profile, permissions } = useAuth();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
 
   const role = (profile?.role || 'user') as UserRole;
@@ -135,11 +135,11 @@ export function Sidebar({ isMobile = false, isOpen = true, onClose = () => {} }:
   const filteredSidebarItems = useMemo(() => {
     return sidebarItems.filter(item => {
       if (item.children) {
-        return item.children.some(child => hasFeature(role, child.featureKey));
+        return item.children.some(child => hasFeature(role, child.featureKey, permissions));
       }
-      return item.featureKey ? hasFeature(role, item.featureKey) : true;
+      return item.featureKey ? hasFeature(role, item.featureKey, permissions) : true;
     });
-  }, [role]);
+  }, [role, permissions]);
 
   useEffect(() => {
     console.log('🔍 Sidebar - role:', role);
@@ -172,7 +172,7 @@ export function Sidebar({ isMobile = false, isOpen = true, onClose = () => {} }:
 
     if (hasChildren) {
       const visibleChildren = item.children!.filter(
-        child => hasFeature(role, (child as any).featureKey)
+        child => hasFeature(role, (child as any).featureKey, permissions)
       );
       if (visibleChildren.length === 0) return null;
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -70,6 +70,7 @@ export interface AuthContextType {
   isAdmin: boolean;
   refreshProfile: () => Promise<void>;
   clearTokens: () => void;
+  permissions: Record<string, boolean>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -95,6 +96,7 @@ interface AuthProviderProps {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [permissions, setPermissions] = useState<Record<string, boolean>>({});
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
   const [initialized, setInitialized] = useState(false);
@@ -167,6 +169,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         if (profileData.email) {
           profileData.email = profileData.email.toLowerCase();
         }
+
+        const { data: permissionData, error: permissionError } = await supabase
+          .from('user_permissions')
+          .select('permission_name, granted')
+          .eq('user_id', userId);
+
+        if (permissionError) throw permissionError;
+
+        setPermissions(Object.fromEntries(
+          (permissionData || []).map(permission => [permission.permission_name, permission.granted === true])
+        ));
         return profileData;
       } catch (fetchError) {
         lastError = fetchError;
@@ -309,12 +322,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           setSession(null);
           setUser(null);
           setProfile(null);
+          setPermissions({});
         }
       } else {
         if (mountedRef.current) {
           setSession(null);
           setUser(null);
           setProfile(null);
+          setPermissions({});
         }
       }
     } catch (error) {
@@ -426,7 +441,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                   setProfile(profile || {
                     id: sessionData.session.user.id,
                     email: (sessionData.session.user.email || '').toLowerCase(),
-                    role: 'admin',
+                    role: 'user',
                     status: 'active',
                     created_at: new Date().toISOString(),
                     updated_at: new Date().toISOString()
@@ -438,7 +453,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                   setProfile({
                     id: sessionData.session.user.id,
                     email: (sessionData.session.user.email || '').toLowerCase(),
-                    role: 'admin',
+                    role: 'user',
                     status: 'active',
                     created_at: new Date().toISOString(),
                     updated_at: new Date().toISOString()
@@ -564,7 +579,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
               const fallbackProfile: UserProfile = {
                 id: signedInUser.id,
                 email: (signedInUser.email || '').toLowerCase(),
-                role: 'admin',
+                role: 'user',
                 status: 'active',
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString()
@@ -613,7 +628,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           const fallbackProfile: UserProfile = {
             id: signedInUser.id,
             email: (signedInUser.email || '').toLowerCase(),
-            role: 'admin',
+            role: 'user',
             status: 'active',
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString()
@@ -726,6 +741,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         // Still clear local state on error - user may have network issues
         setUser(null);
         setProfile(null);
+        setPermissions({});
         setSession(null);
         clearAuthTokens();
 
@@ -737,6 +753,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         // Clear state immediately
         setUser(null);
         setProfile(null);
+        setPermissions({});
         setSession(null);
 
         // Clear local storage
@@ -955,6 +972,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     clearAuthTokens();
     setUser(null);
     setProfile(null);
+    setPermissions({});
     setSession(null);
     toast.info('Authentication tokens cleared. Please sign in again.');
   }, []);
@@ -979,6 +997,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     isAdmin,
     refreshProfile,
     clearTokens,
+    permissions,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -11,8 +11,6 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { PaginationControls } from '@/components/pagination/PaginationControls';
 import { usePagination } from '@/hooks/usePagination';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertCircle } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -46,9 +44,6 @@ import {
 } from 'lucide-react';
 import { usePayments, useCompanies, useDeletePayment } from '@/hooks/useDatabase';
 import { useInvoicesFixed as useInvoices } from '@/hooks/useInvoicesFixed';
-import { useAuth } from '@/contexts/AuthContext';
-import { hasFeature } from '@/utils/rolePermissions';
-import type { UserRole } from '@/utils/rolePermissions';
 import { generatePaymentReceiptPDF } from '@/utils/pdfGenerator';
 import { formatCurrency as formatCurrencyUtil } from '@/utils/currencyFormatter';
 
@@ -127,7 +122,6 @@ function formatCurrency(amount: number, currency: string = 'KES') {
 }
 
 export default function Payments() {
-  const { profile } = useAuth();
   const [searchParams] = useSearchParams();
   const [searchTerm, setSearchTerm] = useState('');
   const [methodFilter, setMethodFilter] = useState<string>('all');
@@ -139,32 +133,6 @@ export default function Payments() {
   const [expandedPayments, setExpandedPayments] = useState<Set<string>>(new Set());
   const [showInvoiceModal, setShowInvoiceModal] = useState(false);
   const [selectedInvoice, setSelectedInvoice] = useState<any>(null);
-
-  const role = (profile?.role || 'user') as UserRole;
-
-  if (!hasFeature(role, 'payments')) {
-    return (
-      <div className="space-y-6 p-6">
-        <Alert className="border-red-200 bg-red-50">
-          <AlertCircle className="h-4 w-4 text-red-600" />
-          <AlertDescription className="text-red-900">
-            You don't have permission to access Payments.
-          </AlertDescription>
-        </Alert>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Access Denied</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-slate-600">
-              You don't have permission to view or manage payments. Please contact your administrator if you believe this is an error.
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
 
   // Set method filter from URL params
   useEffect(() => {

--- a/src/utils/rolePermissions.ts
+++ b/src/utils/rolePermissions.ts
@@ -44,7 +44,12 @@ const ROLE_PERMISSIONS: Record<UserRole, FeatureKey[]> = {
   ],
 };
 
-export function hasFeature(role: UserRole | null | undefined, feature: FeatureKey): boolean {
+export function hasFeature(
+  role: UserRole | null | undefined,
+  feature: FeatureKey,
+  overrides?: Record<string, boolean | null>
+): boolean {
+  if (overrides && feature in overrides) return overrides[feature] === true;
   if (!role) return false;
   const features = ROLE_PERMISSIONS[role];
   return features ? features.includes(feature) : false;

--- a/src/utils/verifyManualSetup.ts
+++ b/src/utils/verifyManualSetup.ts
@@ -115,7 +115,7 @@ export async function verifyManualSetup() {
     const { data: profiles, error } = await supabase
       .from('profiles')
       .select('id, email, role')
-      .eq('role', 'super_admin')
+      .eq('role', 'admin')
       .limit(1);
 
     if (!error && profiles && profiles.length > 0) {


### PR DESCRIPTION
### Summary
Fixes incorrect permission handling that caused the Payments page to show a false "permissions issue" for users who should have access, by introducing per-user permission overrides pulled from the database.

### Problem
The Payments page (and other role-gated UI) relied solely on static role-based permissions, which didn't account for individually granted or revoked permissions. This caused users to see an "Access Denied" message on the Payments page even when they should have had access, and the underlying permission check logic wasn't flexible enough to support per-user overrides.

### Solution
Added a `user_permissions` lookup to `AuthContext` that fetches per-user permission overrides and exposes them via context. Updated `hasFeature` to accept these overrides and prioritize them over the default role-based permission table. Removed the redundant, hardcoded permission check block in the Payments page since access control is now consistently handled via `ProtectedRoute` using the updated `hasFeature` logic.

### Key Changes
- `AuthContext`: added `permissions` state populated from `user_permissions` table (`permission_name`, `granted`), reset on sign-out/errors, and exposed via `AuthContextType`.
- `rolePermissions.ts`: `hasFeature` now accepts an optional `overrides` map and returns the override value when present, falling back to role-based permissions otherwise.
- `ProtectedRoute`: passes `permissions` from `useAuth` into `hasFeature`, and simplified the `requiredFeature` check to not require a `role` to be set.
- `Sidebar`: passes `permissions` into all `hasFeature` calls and updated the `useMemo` dependency array accordingly.
- `Payments.tsx`: removed the manual role/permission check and "Access Denied" UI, relying on `ProtectedRoute` for access control.
- `verifyManualSetup.ts`: updated admin role check from `super_admin` to `admin` to match actual role values.
- Fixed fallback profile role defaults from `admin` to `user` in `AuthContext` to avoid over-privileged fallback profiles.


---

<a href="https://builder.io/app/projects/ebda08af64d5407ab46b/broad-zone-phymmw3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ebda08af64d5407ab46b-broad-zone-phymmw3b.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ebda08af64d5407ab46b&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 340`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ebda08af64d5407ab46b</projectId>-->
<!--<branchName>broad-zone-phymmw3b</branchName>-->