### PR TITLE
Fix incorrect previous balance on payment receipt PDFs

### DIFF
--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -922,7 +922,8 @@ export const usePayments = (companyId?: string) => {
             updated_at
           `)
           .eq('company_id', companyId)
-          .order('created_at', { ascending: false });
+          .order('created_at', { ascending: true })
+          .order('id', { ascending: true });
 
         const { data: payments, error: paymentsError } = await query;
 

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -46,6 +46,7 @@ import { usePayments, useCompanies, useDeletePayment } from '@/hooks/useDatabase
 import { useInvoicesFixed as useInvoices } from '@/hooks/useInvoicesFixed';
 import { generatePaymentReceiptPDF } from '@/utils/pdfGenerator';
 import { formatCurrency as formatCurrencyUtil } from '@/utils/currencyFormatter';
+import { getReceiptBalances } from '@/utils/paymentReceiptBalances';
 
 interface Payment {
   id: string;
@@ -56,6 +57,7 @@ interface Payment {
   payment_method: 'cash' | 'mpesa' | 'mobile_money' | 'bank_transfer' | 'cheque';
   reference_number?: string;
   notes?: string;
+  created_at?: string | null;
   customers?: {
     name: string;
     email?: string;
@@ -225,30 +227,24 @@ export default function Payments() {
         toast.warning('No invoices associated with this payment. Receipt will be generated without invoice particulars.');
       }
 
-      // Enrich payment data with invoice balance information
+      const invoiceTotals = new Map(
+        invoices.map(invoice => [invoice.id, Number(invoice.total_amount || 0)]),
+      );
+      const receiptBalances = getReceiptBalances(payments, invoiceTotals);
+
       const enrichedPayment = {
         ...payment,
         payment_allocations: payment.payment_allocations?.map(alloc => {
-          // Find the corresponding invoice to get balance information
           const invoice = invoices.find(inv => inv.invoice_number === alloc.invoice_number);
+          const balance = receiptBalances.get(`${payment.id}:${alloc.id}`);
 
-          // Calculate previous balance (balance before this payment)
-          const currentBalanceDue = invoice?.balance_due || 0;
-          const previousBalance = currentBalanceDue + alloc.allocated_amount;
-
-          // Calculate due amount after this payment
-          const dueAmount = Math.max(0, previousBalance - alloc.allocated_amount);
-
-          const enrichedAlloc = {
+          return {
             ...alloc,
             paid_amount: invoice?.paid_amount || 0,
             balance_due: invoice?.balance_due || 0,
-            previous_balance: previousBalance,
-            due_amount: dueAmount
+            previous_balance: balance?.previous_balance ?? Number(alloc.invoice_total || 0),
+            due_amount: balance?.current_balance ?? Math.max(0, Number(alloc.invoice_total || 0) - Number(alloc.allocated_amount || 0))
           };
-
-          console.log('Enriched allocation:', enrichedAlloc);
-          return enrichedAlloc;
         }) || []
       };
 

--- a/src/utils/paymentReceiptBalances.test.ts
+++ b/src/utils/paymentReceiptBalances.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from 'node:assert';
+import { getReceiptBalances, ReceiptPayment } from './paymentReceiptBalances';
+
+const allocation = (id: string, amount: number, createdAt?: string, invoiceId = 'invoice-1') => ({
+  id,
+  invoice_id: invoiceId,
+  invoice_number: 'INV-001',
+  allocated_amount: amount,
+  invoice_total: 1000,
+  allocation_created_at: createdAt,
+});
+
+const payments: ReceiptPayment[] = [
+  {
+    id: 'payment-2',
+    created_at: '2026-06-02T10:00:00Z',
+    payment_allocations: [allocation('allocation-2', 300)],
+  },
+  {
+    id: 'payment-1',
+    created_at: '2026-06-01T10:00:00Z',
+    payment_allocations: [
+      allocation('allocation-1', 200),
+      allocation('allocation-3', 100, '2026-06-01T10:01:00Z'),
+    ],
+  },
+];
+
+const balances = getReceiptBalances(payments);
+assert.deepEqual(balances.get('payment-1:allocation-1'), { previous_balance: 1000, current_balance: 800 });
+assert.deepEqual(balances.get('payment-1:allocation-3'), { previous_balance: 800, current_balance: 700 });
+assert.deepEqual(balances.get('payment-2:allocation-2'), { previous_balance: 700, current_balance: 400 });
+
+const overpayment = getReceiptBalances([{
+  id: 'payment-3',
+  payment_date: '2026-06-03',
+  payment_allocations: [allocation('allocation-4', 1500)],
+}]);
+assert.deepEqual(overpayment.get('payment-3:allocation-4'), { previous_balance: 1000, current_balance: 0 });
+
+const tiedPayments = getReceiptBalances([
+  { id: 'payment-b', created_at: '2026-06-04T10:00:00Z', payment_allocations: [allocation('b', 100)] },
+  { id: 'payment-a', created_at: '2026-06-04T10:00:00Z', payment_allocations: [allocation('a', 100)] },
+]);
+assert.deepEqual(tiedPayments.get('payment-a:a'), { previous_balance: 1000, current_balance: 900 });
+assert.deepEqual(tiedPayments.get('payment-b:b'), { previous_balance: 900, current_balance: 800 });

--- a/src/utils/paymentReceiptBalances.ts
+++ b/src/utils/paymentReceiptBalances.ts
@@ -1,0 +1,84 @@
+export interface ReceiptAllocation {
+  id: string;
+  invoice_id?: string | null;
+  invoice_number: string;
+  allocated_amount: number;
+  invoice_total: number;
+  allocation_created_at?: string | null;
+}
+
+export interface ReceiptPayment {
+  id: string;
+  created_at?: string | null;
+  payment_date?: string | null;
+  payment_allocations?: ReceiptAllocation[];
+}
+
+export interface ReceiptBalance {
+  previous_balance: number;
+  current_balance: number;
+}
+
+const timestampValue = (value?: string | null) => {
+  if (!value) return Number.POSITIVE_INFINITY;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? Number.POSITIVE_INFINITY : timestamp;
+};
+
+export function getReceiptBalances(
+  payments: ReceiptPayment[],
+  invoiceTotals: Map<string, number> = new Map(),
+): Map<string, ReceiptBalance> {
+  const allocations = payments.flatMap((payment, paymentIndex) =>
+    (payment.payment_allocations || []).map((allocation, allocationIndex) => ({
+      payment,
+      allocation,
+      paymentIndex,
+      allocationIndex,
+    })),
+  );
+
+  const byInvoice = new Map<string, typeof allocations>();
+  allocations.forEach((entry) => {
+    const invoiceKey = entry.allocation.invoice_id || entry.allocation.invoice_number;
+    const invoiceAllocations = byInvoice.get(invoiceKey) || [];
+    invoiceAllocations.push(entry);
+    byInvoice.set(invoiceKey, invoiceAllocations);
+  });
+
+  const balances = new Map<string, ReceiptBalance>();
+
+  byInvoice.forEach((invoiceAllocations) => {
+    invoiceAllocations.sort((a, b) => {
+      const paymentTime = timestampValue(a.payment.created_at || a.payment.payment_date)
+        - timestampValue(b.payment.created_at || b.payment.payment_date);
+      if (paymentTime !== 0) return paymentTime;
+
+      const allocationTime = timestampValue(a.allocation.allocation_created_at)
+        - timestampValue(b.allocation.allocation_created_at);
+      if (allocationTime !== 0) return allocationTime;
+
+      const idOrder = a.allocation.id.localeCompare(b.allocation.id);
+      if (idOrder !== 0) return idOrder;
+
+      return a.paymentIndex - b.paymentIndex || a.allocationIndex - b.allocationIndex;
+    });
+
+    const firstAllocation = invoiceAllocations[0].allocation;
+    const invoiceTotal = invoiceTotals.get(firstAllocation.invoice_id || '')
+      ?? Number(firstAllocation.invoice_total || 0);
+    let runningBalance = invoiceTotal;
+
+    invoiceAllocations.forEach(({ payment, allocation }) => {
+      const previousBalance = runningBalance;
+      const currentBalance = Math.max(0, previousBalance - Number(allocation.allocated_amount || 0));
+      balances.set(`${payment.id}:${allocation.id}`, {
+        previous_balance: previousBalance,
+        current_balance: currentBalance,
+      });
+      runningBalance = currentBalance;
+    });
+  });
+
+  return balances;
+}


### PR DESCRIPTION
### Summary
Fixes payment receipt PDFs showing the wrong previous balance when a customer has multiple receipts against the same invoice.

### Problem
When several receipts existed for an invoice, each PDF displayed the same (current) balance instead of the balance as it stood right before that specific payment, making the receipts inaccurate for tracking payment history.

### Solution
Introduced a dedicated utility that computes previous/current balances per allocation by replaying payments chronologically against each invoice's total, instead of deriving the previous balance from the invoice's latest balance_due.

### Key Changes
- Added `src/utils/paymentReceiptBalances.ts` exposing `getReceiptBalances`, which sorts payment allocations per invoice by payment `created_at`/`payment_date`, then allocation `created_at`, then id, and walks the running balance forward to compute `previous_balance` and `current_balance` for each allocation.
- Added unit tests (`paymentReceiptBalances.test.ts`) covering multi-payment ordering, tied timestamps, and overpayment scenarios.
- Updated `Payments.tsx` to build invoice totals and use `getReceiptBalances` when enriching a payment's allocations for PDF generation, replacing the previous single-invoice balance_due based calculation and removing a stray debug `console.log`.
- Updated `usePayments` query in `useDatabase.ts` to order payments by `created_at` ascending (with `id` as tiebreaker) so payments are processed chronologically.

---

<a href="https://builder.io/app/projects/279aa37c96134ecb904d/bright-handle-pd65c1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://279aa37c96134ecb904d-bright-handle-pd65c1ef.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=279aa37c96134ecb904d&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 341`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>279aa37c96134ecb904d</projectId>-->
<!--<branchName>bright-handle-pd65c1ef</branchName>-->