### PR TITLE
Fix flash of "Access denied" on protected feature routes

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -22,7 +22,7 @@ export function ProtectedRoute({
   allowedRoles,
   requiredFeature,
 }: ProtectedRouteProps) {
-  const { isAuthenticated, loading, profile, permissions } = useAuth();
+  const { isAuthenticated, loading, profile, permissions, profileReady } = useAuth();
   const [sessionVerified, setSessionVerified] = useState(false);
   const [verifyingSession, setVerifyingSession] = useState(false);
 
@@ -50,7 +50,7 @@ export function ProtectedRoute({
     verifySuperbaseSession();
   }, [isAuthenticated, loading]);
 
-  if (loading || verifyingSession) {
+  if (loading || verifyingSession || (requiredFeature && isAuthenticated && !profileReady)) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -71,6 +71,7 @@ export interface AuthContextType {
   refreshProfile: () => Promise<void>;
   clearTokens: () => void;
   permissions: Record<string, boolean>;
+  profileReady: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -97,6 +98,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [permissions, setPermissions] = useState<Record<string, boolean>>({});
+  const [profileReady, setProfileReady] = useState(false);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
   const [initialized, setInitialized] = useState(false);
@@ -296,7 +298,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           setSession(newSession);
           setUser(newSession.user);
           setProfile(userProfile);
-          
+          setProfileReady(true);
+
           // Update last login for sign-in events, but don't await to prevent blocking
           if (event === 'SIGNED_IN' && userProfile) {
             updateLastLogin(newSession.user.id).catch(err =>
@@ -323,6 +326,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           setUser(null);
           setProfile(null);
           setPermissions({});
+          setProfileReady(true);
         }
       } else {
         if (mountedRef.current) {
@@ -330,6 +334,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           setUser(null);
           setProfile(null);
           setPermissions({});
+          setProfileReady(true);
         }
       }
     } catch (error) {
@@ -423,6 +428,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
             setSession(sessionData.session);
             setUser(sessionData.session.user);
+            setProfileReady(false);
 
             // Fetch profile in background with timeout
             const profileTimeoutPromise = new Promise<UserProfile | null>((resolve) => {
@@ -446,6 +452,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     created_at: new Date().toISOString(),
                     updated_at: new Date().toISOString()
                   } as UserProfile);
+                  setProfileReady(true);
                 }
               })
               .catch(() => {
@@ -458,6 +465,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     created_at: new Date().toISOString(),
                     updated_at: new Date().toISOString()
                   } as UserProfile);
+                  setProfileReady(true);
                 }
               });
           }
@@ -550,6 +558,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         console.log('📝 [AuthContext] Setting session and user state after sign in');
         setSession(session);
         setUser(signedInUser);
+        setProfileReady(false);
 
         try {
           // Fetch profile with timeout before clearing loading state
@@ -573,6 +582,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 userProfile.email = userProfile.email.toLowerCase();
               }
               setProfile(userProfile);
+              setProfileReady(true);
               console.log('✅ Profile loaded successfully during sign in');
             } else {
               // Create minimal profile as fallback to allow app to function
@@ -585,6 +595,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 updated_at: new Date().toISOString()
               };
               setProfile(fallbackProfile);
+              setProfileReady(true);
               console.warn('⚠️ Profile fetch returned null, using fallback profile');
             }
 
@@ -634,6 +645,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             updated_at: new Date().toISOString()
           };
           setProfile(fallbackProfile);
+          setProfileReady(true);
         }
         clearTimeout(hardTimeoutId);
         setTimeout(() => toast.success('Signed in successfully'), 0);
@@ -973,6 +985,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setUser(null);
     setProfile(null);
     setPermissions({});
+    setProfileReady(true);
     setSession(null);
     toast.info('Authentication tokens cleared. Please sign in again.');
   }, []);
@@ -998,6 +1011,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     refreshProfile,
     clearTokens,
     permissions,
+    profileReady,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
### Summary
Prevents a brief "Access denied" flash on feature-gated routes (like /payments) by waiting for the user profile to be fully loaded before evaluating access.

### Problem
Pages guarded by `requiredFeature` checks briefly showed "Access denied" while the user's profile was still being fetched, before correctly showing the page once the profile loaded. This happened because `ProtectedRoute` evaluated permissions before the profile data was ready.

### Solution
Introduced a `profileReady` flag in `AuthContext` that tracks whether the profile fetch has completed. `ProtectedRoute` now shows a loading state instead of evaluating feature access until the profile is confirmed ready.

### Key Changes
- Added `profileReady` state and exposed it via `AuthContextType`
- Set `profileReady` to `false` whenever a new session/profile fetch begins, and `true` once the profile (or fallback profile) is set, including sign-in, sign-out, token clearing, and auth state change handlers
- Updated `ProtectedRoute` to keep showing the loading spinner while `requiredFeature` is set, the user is authenticated, and `profileReady` is still `false`


---

<a href="https://builder.io/app/projects/d7a00d7ea4f04f8487ee/cinder-track-ncp8znx2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://d7a00d7ea4f04f8487ee-cinder-track-ncp8znx2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=d7a00d7ea4f04f8487ee&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 344`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7a00d7ea4f04f8487ee</projectId>-->
<!--<branchName>cinder-track-ncp8znx2</branchName>-->