### PR TITLE
Fix permission save atomicity, RLS policies, and logout hang

### DIFF
--- a/USER_MANAGEMENT_SETUP_GUIDE.md
+++ b/USER_MANAGEMENT_SETUP_GUIDE.md
@@ -444,6 +444,10 @@ npm install -g supabase
 supabase functions deploy create-user
 supabase functions deploy delete-user
 supabase functions deploy send-invitation
+supabase functions deploy save-user-permissions
+
+# Apply the permission schema, RLS policies, and transactional save RPC
+supabase db push
 ```
 
 ## Option 2: External Backend API

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -140,6 +140,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const mountedRef = useRef(true);
   const initializingRef = useRef(false);
   const forceCompletedRef = useRef(false);
+  const signingOutRef = useRef(false);
 
   // Toast spam prevention
   const lastNetworkErrorToast = useRef<number>(0);
@@ -287,7 +288,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   // Handle auth state changes with improved error handling
   const handleAuthStateChange = useCallback(async (event: string, newSession: Session | null) => {
-    if (!mountedRef.current || initializingRef.current) return;
+    if (!mountedRef.current || initializingRef.current || signingOutRef.current) return;
 
     
     try {
@@ -407,7 +408,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             sessionTimeoutPromise
           ]) as any;
 
-          if (sessionData?.session?.user && mountedRef.current) {
+          if (sessionData?.session?.user && mountedRef.current && !signingOutRef.current) {
             console.log('✅ [AuthContext] Session found, user:', sessionData.session.user.email);
             console.log('📋 [AuthContext] Session tokens:', {
               hasAccessToken: !!sessionData.session.access_token,
@@ -751,11 +752,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, []);
 
   const signOut = useCallback(async () => {
+    signingOutRef.current = true;
+
     try {
-      console.log('���� Starting sign out process...');
+      console.log('Starting sign out process...');
       setLoading(true);
 
-      const { error } = await supabase.auth.signOut();
+      const { error } = await supabase.auth.signOut({ scope: 'local' });
 
       if (error) {
         // Better error message handling
@@ -838,6 +841,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       if (mountedRef.current) {
         setLoading(false);
       }
+      signingOutRef.current = false;
     }
   }, []);
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -501,26 +501,26 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     if (!user) return;
 
     const pollInterval = setInterval(() => {
-      if (mountedRef.current) {
-        supabase
-          .from('user_permissions')
-          .select('permission_name, granted')
-          .eq('user_id', user.id)
-          .then(({ data: permissionData, error: permissionError }) => {
-            if (permissionError) {
-              console.warn('[AuthContext] Permission poll error:', permissionError.message);
-              return;
-            }
-            if (mountedRef.current) {
-              setPermissions(Object.fromEntries(
-                (permissionData || []).map(permission => [permission.permission_name, permission.granted === true])
-              ));
-            }
-          })
-          .catch(err => {
-            console.warn('[AuthContext] Permission poll failed:', err instanceof Error ? err.message : String(err));
-          });
-      }
+      if (!mountedRef.current || window.location.pathname === '/settings/permissions') return;
+
+      supabase
+        .from('user_permissions')
+        .select('permission_name, granted')
+        .eq('user_id', user.id)
+        .then(({ data: permissionData, error: permissionError }) => {
+          if (permissionError) {
+            console.warn('[AuthContext] Permission poll error:', permissionError.message);
+            return;
+          }
+          if (mountedRef.current) {
+            setPermissions(Object.fromEntries(
+              (permissionData || []).map(permission => [permission.permission_name, permission.granted === true])
+            ));
+          }
+        })
+        .catch(err => {
+          console.warn('[AuthContext] Permission poll failed:', err instanceof Error ? err.message : String(err));
+        });
     }, 8000);
 
     return () => clearInterval(pollInterval);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2216,7 +2216,7 @@ export type Database = {
           granted_by?: string | null
           id?: string
           permission_name: string
-          user_id?: string | null
+          user_id: string
         }
         Update: {
           granted?: boolean | null
@@ -2224,7 +2224,7 @@ export type Database = {
           granted_by?: string | null
           id?: string
           permission_name?: string
-          user_id?: string | null
+          user_id?: string
         }
         Relationships: [
           {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2208,7 +2208,7 @@ export type Database = {
           granted_by: string | null
           id: string
           permission_name: string
-          user_id: string | null
+          user_id: string
         }
         Insert: {
           granted?: boolean | null

--- a/src/pages/settings/UserPermissions.tsx
+++ b/src/pages/settings/UserPermissions.tsx
@@ -68,7 +68,7 @@ export default function UserPermissions() {
       if (profileError) throw profileError;
       const userIds = (profiles || []).map(p => p.id);
 
-      let permMap: Record<string, Record<string, boolean>> = {};
+      const permMap: Record<string, Record<string, boolean>> = {};
       if (userIds.length > 0) {
         const { data: perms, error: permError } = await supabase
           .from('user_permissions')
@@ -104,11 +104,12 @@ export default function UserPermissions() {
   }, [loadUsers]);
 
   const toggleOverride = (userId: string, feature: FeatureKey) => {
-    setUsers(prev => prev.map(u =>
-      u.id === userId
-        ? { ...u, overrides: { ...u.overrides, [feature]: !u.overrides[feature] }, changed: true }
-        : u
-    ));
+    setUsers(prev => prev.map(u => {
+      if (u.id !== userId) return u;
+
+      const currentValue = feature in u.overrides ? u.overrides[feature] : hasFeature(u.role, feature);
+      return { ...u, overrides: { ...u.overrides, [feature]: !currentValue }, changed: true };
+    }));
   };
 
   const savePermissions = async (userId: string) => {
@@ -117,12 +118,7 @@ export default function UserPermissions() {
 
     setSaving(userId);
     try {
-      const result = await saveUserPermissions(
-        userId,
-        profile.id,
-        user.overrides,
-        user.role
-      );
+      const result = await saveUserPermissions(userId, user.overrides, user.role);
 
       if (result.success) {
         toast.success(
@@ -287,12 +283,13 @@ export default function UserPermissions() {
             if (!confirm('Clear all permission overrides for your company?')) return;
             setLoading(true);
             try {
-              const userIds = users.map(u => u.id);
-              if (userIds.length > 0) {
-                const { error } = await supabase.from('user_permissions').delete().in('user_id', userIds);
-                if (error) throw error;
-              }
+              const results = await Promise.all(
+                users.map((user) => saveUserPermissions(user.id, {}, user.role))
+              );
+              const failedResult = results.find((result) => !result.success);
+              if (failedResult) throw new Error(failedResult.error?.message || 'Permission reset failed');
               await loadUsers();
+              await refreshPermissions();
               toast.success('Overrides cleared');
             } catch (err) {
               toast.error(`Clear failed: ${parseErrorMessage(err)}`);

--- a/src/utils/permissionSaveHelper.ts
+++ b/src/utils/permissionSaveHelper.ts
@@ -1,6 +1,5 @@
 import { supabase } from '@/integrations/supabase/client';
-import { getAllowedFeatures, FeatureKey, UserRole } from '@/utils/rolePermissions';
-import type { Database } from '@/integrations/supabase/types';
+import { UserRole } from '@/utils/rolePermissions';
 
 export interface PermissionSaveError {
   code: string;
@@ -15,207 +14,32 @@ export interface PermissionSaveResult {
   rowsInserted?: number;
 }
 
-/**
- * Validates that the requester is an admin in the target user's company.
- * This provides a defensive check at the application layer (RLS also enforces this).
- */
-async function validateAdminPermission(
-  requesterId: string,
-  targetUserId: string
-): Promise<{ isAuthorized: boolean; error?: PermissionSaveError }> {
-  try {
-    // Fetch both user profiles to verify company match and admin status
-    const { data: requester, error: requesterError } = await supabase
-      .from('profiles')
-      .select('id, role, company_id')
-      .eq('id', requesterId)
-      .maybeSingle();
-
-    if (requesterError) {
-      return {
-        isAuthorized: false,
-        error: {
-          code: 'FETCH_REQUESTER_FAILED',
-          message: 'Failed to load requester profile',
-          details: requesterError.message
-        }
-      };
-    }
-
-    if (!requester) {
-      return {
-        isAuthorized: false,
-        error: {
-          code: 'REQUESTER_NOT_FOUND',
-          message: 'Requester profile not found'
-        }
-      };
-    }
-
-    if (requester.role !== 'admin') {
-      return {
-        isAuthorized: false,
-        error: {
-          code: 'INSUFFICIENT_ROLE',
-          message: 'Only admins can modify permissions'
-        }
-      };
-    }
-
-    const { data: target, error: targetError } = await supabase
-      .from('profiles')
-      .select('id, company_id')
-      .eq('id', targetUserId)
-      .maybeSingle();
-
-    if (targetError) {
-      return {
-        isAuthorized: false,
-        error: {
-          code: 'FETCH_TARGET_FAILED',
-          message: 'Failed to load target user profile',
-          details: targetError.message
-        }
-      };
-    }
-
-    if (!target) {
-      return {
-        isAuthorized: false,
-        error: {
-          code: 'TARGET_NOT_FOUND',
-          message: 'Target user profile not found'
-        }
-      };
-    }
-
-    if (requester.company_id !== target.company_id) {
-      return {
-        isAuthorized: false,
-        error: {
-          code: 'CROSS_COMPANY_DENIED',
-          message: 'Cannot modify permissions for users in other companies'
-        }
-      };
-    }
-
-    return { isAuthorized: true };
-  } catch (error) {
-    return {
-      isAuthorized: false,
-      error: {
-        code: 'VALIDATION_ERROR',
-        message: 'Unexpected error during authorization check',
-        details: error instanceof Error ? error.message : String(error)
-      }
-    };
-  }
-}
-
-/**
- * Atomically save user permission overrides.
- *
- * This function:
- * 1. Validates that the requester is an admin in the target user's company
- * 2. Deletes all existing overrides for the user
- * 3. Inserts only non-default overrides
- * 4. Handles errors gracefully with detailed feedback
- *
- * @param userId - The user whose permissions are being modified
- * @param requesterId - The admin user making the change
- * @param overrides - Map of feature keys to granted boolean values
- * @param userRole - The user's role (used to compute defaults)
- * @returns Result object with success status and metadata
- */
 export async function saveUserPermissions(
   userId: string,
-  requesterId: string,
   overrides: Record<string, boolean>,
-  userRole: UserRole
+  _userRole: UserRole
 ): Promise<PermissionSaveResult> {
-  // Step 1: Validate authorization
-  const authCheck = await validateAdminPermission(requesterId, userId);
-  if (!authCheck.isAuthorized) {
+  const { data, error } = await supabase.functions.invoke('save-user-permissions', {
+    body: { userId, overrides },
+  });
+
+  if (error) {
     return {
       success: false,
-      error: authCheck.error || {
-        code: 'AUTHORIZATION_FAILED',
-        message: 'Authorization check failed'
-      }
+      error: { code: 'SAVE_FAILED', message: error.message },
     };
   }
 
-  try {
-    // Step 2: Compute which overrides are actually non-default
-    const roleDefaults = getAllowedFeatures(userRole);
-    const effectiveOverrides: Array<[string, boolean]> = Object.entries(overrides)
-      .filter(([key, granted]) => {
-        const defaultValue = roleDefaults.includes(key as FeatureKey);
-        return granted !== defaultValue;
-      });
-
-    // Step 3: Delete all existing overrides for this user
-    const { error: deleteError, count: deletedCount } = await supabase
-      .from('user_permissions')
-      .delete()
-      .eq('user_id', userId);
-
-    if (deleteError) {
-      return {
-        success: false,
-        error: {
-          code: 'DELETE_FAILED',
-          message: 'Failed to clear existing permission overrides',
-          details: deleteError.message
-        }
-      };
-    }
-
-    // Step 4: Insert new overrides (if any)
-    let insertedCount = 0;
-    if (effectiveOverrides.length > 0) {
-      const rowsToInsert = effectiveOverrides.map(([permission_name, granted]) => ({
-        user_id: userId,
-        permission_name,
-        granted,
-        granted_by: requesterId,
-        granted_at: new Date().toISOString()
-      }));
-
-      const { error: insertError, data: insertedRows } = await supabase
-        .from('user_permissions')
-        .insert(rowsToInsert)
-        .select();
-
-      if (insertError) {
-        // Attempt to recover: if insert failed, at least we cleared the old overrides
-        // This is safer than keeping stale data
-        return {
-          success: false,
-          error: {
-            code: 'INSERT_FAILED',
-            message: 'Failed to insert new permission overrides (old overrides were cleared)',
-            details: insertError.message
-          }
-        };
-      }
-
-      insertedCount = insertedRows?.length || 0;
-    }
-
-    return {
-      success: true,
-      rowsDeleted: deletedCount || 0,
-      rowsInserted: insertedCount
-    };
-  } catch (error) {
+  if (!data?.success) {
     return {
       success: false,
-      error: {
-        code: 'UNEXPECTED_ERROR',
-        message: 'Unexpected error during permission save',
-        details: error instanceof Error ? error.message : String(error)
-      }
+      error: { code: 'SAVE_FAILED', message: data?.error || 'Permission save failed' },
     };
   }
+
+  return {
+    success: true,
+    rowsDeleted: data.rowsDeleted,
+    rowsInserted: data.rowsInserted,
+  };
 }

--- a/src/utils/permissionSaveHelper.ts
+++ b/src/utils/permissionSaveHelper.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase/client';
 import { UserRole } from '@/utils/rolePermissions';
 
 export interface PermissionSaveError {
@@ -24,16 +25,32 @@ export async function saveUserPermissions(
   });
 
   if (error) {
+    const message = error.message || '';
+    const isUnavailable = error.name === 'FunctionsFetchError' || message.toLowerCase().includes('failed to send a request');
+
     return {
       success: false,
-      error: { code: 'SAVE_FAILED', message: error.message },
+      error: {
+        code: isUnavailable ? 'SAVE_SERVICE_UNAVAILABLE' : 'SAVE_FAILED',
+        message: isUnavailable
+          ? 'Permission service is unavailable. Ask an administrator to deploy the save-user-permissions function.'
+          : message || 'Permission save failed',
+        details: message || undefined,
+      },
     };
   }
 
   if (!data?.success) {
+    const message = data?.error || 'Permission save failed';
+    const isAuthorizationError = /only admins|other companies|unauthorized/i.test(message);
+
     return {
       success: false,
-      error: { code: 'SAVE_FAILED', message: data?.error || 'Permission save failed' },
+      error: {
+        code: isAuthorizationError ? 'SAVE_NOT_AUTHORIZED' : 'SAVE_FAILED',
+        message: isAuthorizationError ? 'You are not authorized to change permissions for this user.' : message,
+        details: message,
+      },
     };
   }
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,1 @@
-project_id = "klifzjcfnlaxminytmyh"
+project_id = "eubrvlzkvzevidivsfha"

--- a/supabase/functions/save-user-permissions/index.ts
+++ b/supabase/functions/save-user-permissions/index.ts
@@ -1,0 +1,101 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const rolePermissions: Record<string, string[]> = {
+  admin: [
+    "dashboard", "customers", "products", "quotations", "invoices",
+    "delivery-notes", "cash-receipts", "boqs", "payments", "audit-logs",
+    "reports-overview", "reports-sales", "reports-inventory", "reports-statements",
+    "settings-company", "settings-users", "manage-permissions",
+  ],
+  accountant: [
+    "dashboard", "customers", "invoices", "cash-receipts", "payments",
+    "reports-overview", "reports-sales", "reports-statements",
+  ],
+  stock_manager: [
+    "dashboard", "customers", "products", "delivery-notes", "reports-overview", "reports-inventory",
+  ],
+  user: ["dashboard", "customers", "quotations", "boqs"],
+  sales: [
+    "dashboard", "customers", "products", "quotations", "invoices", "delivery-notes",
+    "cash-receipts", "boqs", "reports-overview", "reports-sales", "reports-inventory", "reports-statements",
+  ],
+};
+
+const validPermissions = new Set(Object.values(rolePermissions).flat());
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), { status: 405, headers: corsHeaders });
+  }
+
+  try {
+    const { userId, overrides } = await req.json();
+    if (typeof userId !== "string" || !overrides || typeof overrides !== "object" || Array.isArray(overrides)) {
+      return new Response(JSON.stringify({ error: "Invalid permission update" }), { status: 400, headers: corsHeaders });
+    }
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: "Missing authorization header" }), { status: 401, headers: corsHeaders });
+    }
+
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") || "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "",
+      { auth: { persistSession: false } },
+    );
+
+    const token = authHeader.replace("Bearer ", "");
+    const { data: authData, error: authError } = await supabaseAdmin.auth.getUser(token);
+    if (authError || !authData.user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: corsHeaders });
+    }
+
+    const { data: targetProfile, error: targetError } = await supabaseAdmin
+      .from("profiles")
+      .select("role")
+      .eq("id", userId)
+      .single();
+
+    if (targetError || !targetProfile || !rolePermissions[targetProfile.role]) {
+      return new Response(JSON.stringify({ error: "Target user not found" }), { status: 404, headers: corsHeaders });
+    }
+
+    const entries = Object.entries(overrides);
+    if (entries.some(([permissionName, granted]) => !validPermissions.has(permissionName) || typeof granted !== "boolean")) {
+      return new Response(JSON.stringify({ error: "Invalid permission update" }), { status: 400, headers: corsHeaders });
+    }
+
+    const defaults = new Set(rolePermissions[targetProfile.role]);
+    const effectiveOverrides = entries
+      .filter(([permissionName, granted]) => granted !== defaults.has(permissionName))
+      .map(([permission_name, granted]) => ({ permission_name, granted }));
+
+    const { data, error } = await supabaseAdmin.rpc("replace_user_permission_overrides", {
+      p_target_user_id: userId,
+      p_requester_id: authData.user.id,
+      p_overrides: effectiveOverrides,
+    });
+
+    if (error) {
+      const status = error.message.includes("Cannot modify") || error.message.includes("Only admins") ? 403 : 400;
+      return new Response(JSON.stringify({ error: error.message }), { status, headers: corsHeaders });
+    }
+
+    const result = data?.[0] || { rows_deleted: 0, rows_inserted: 0 };
+    return new Response(JSON.stringify({ success: true, rowsDeleted: result.rows_deleted, rowsInserted: result.rows_inserted }), { status: 200, headers: corsHeaders });
+  } catch (error) {
+    console.error("Permission save error:", error);
+    return new Response(JSON.stringify({ error: "Internal server error" }), { status: 500, headers: corsHeaders });
+  }
+});

--- a/supabase/migrations/20250901000000_stabilize_user_permissions.sql
+++ b/supabase/migrations/20250901000000_stabilize_user_permissions.sql
@@ -1,0 +1,95 @@
+ALTER TABLE public.user_permissions
+  ALTER COLUMN user_id SET NOT NULL;
+
+ALTER TABLE public.user_permissions
+  DROP CONSTRAINT IF EXISTS user_permissions_user_id_permission_name_key;
+
+ALTER TABLE public.user_permissions
+  ADD CONSTRAINT user_permissions_user_id_permission_name_key UNIQUE (user_id, permission_name);
+
+ALTER TABLE public.user_permissions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view their own permissions" ON public.user_permissions;
+DROP POLICY IF EXISTS "Admins can manage permissions in their company" ON public.user_permissions;
+
+CREATE POLICY "Users can view their own permissions"
+  ON public.user_permissions
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Admins can manage permissions in their company"
+  ON public.user_permissions
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles admin_profile
+      JOIN public.profiles user_profile ON user_profile.id = user_permissions.user_id
+      WHERE admin_profile.id = auth.uid()
+        AND admin_profile.role = 'admin'
+        AND admin_profile.company_id = user_profile.company_id
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles admin_profile
+      JOIN public.profiles user_profile ON user_profile.id = user_permissions.user_id
+      WHERE admin_profile.id = auth.uid()
+        AND admin_profile.role = 'admin'
+        AND admin_profile.company_id = user_profile.company_id
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.replace_user_permission_overrides(
+  p_target_user_id uuid,
+  p_requester_id uuid,
+  p_overrides jsonb
+)
+RETURNS TABLE(rows_deleted integer, rows_inserted integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  requester_company_id uuid;
+  target_company_id uuid;
+  requester_role text;
+  deleted_count integer;
+  inserted_count integer;
+BEGIN
+  SELECT company_id, role::text
+  INTO requester_company_id, requester_role
+  FROM profiles
+  WHERE id = p_requester_id;
+
+  SELECT company_id
+  INTO target_company_id
+  FROM profiles
+  WHERE id = p_target_user_id;
+
+  IF requester_role IS DISTINCT FROM 'admin' THEN
+    RAISE EXCEPTION 'Only admins can modify permissions';
+  END IF;
+
+  IF requester_company_id IS NULL OR requester_company_id IS DISTINCT FROM target_company_id THEN
+    RAISE EXCEPTION 'Cannot modify permissions for users in other companies';
+  END IF;
+
+  DELETE FROM user_permissions
+  WHERE user_id = p_target_user_id;
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+  INSERT INTO user_permissions (user_id, permission_name, granted, granted_by, granted_at)
+  SELECT p_target_user_id, permission_name, granted, p_requester_id, now()
+  FROM jsonb_to_recordset(p_overrides) AS override_row(permission_name text, granted boolean);
+  GET DIAGNOSTICS inserted_count = ROW_COUNT;
+
+  RETURN QUERY SELECT deleted_count, inserted_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.replace_user_permission_overrides(uuid, uuid, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.replace_user_permission_overrides(uuid, uuid, jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.replace_user_permission_overrides(uuid, uuid, jsonb) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.replace_user_permission_overrides(uuid, uuid, jsonb) TO service_role;


### PR DESCRIPTION
### Summary
Stabilizes the `user_permissions` table with proper RLS policies and a transactional save RPC, moves permission saving into a new Supabase Edge Function, and fixes an infinite logout loop in `AuthContext`.

### Problem
Permission overrides were saved from the frontend using a non-atomic delete-then-insert pattern with no error handling, RLS policies on `user_permissions` had drifted across conflicting migration scripts, and `user_id` was incorrectly typed as nullable. Separately, signing out could trigger the auth state change handler repeatedly, causing the app to get stuck in a logout loop.

### Solution
- Introduced a `replace_user_permission_overrides` SQL function (SECURITY DEFINER) that validates the requester is an admin in the target user's company and performs the delete+insert atomically.
- Added a `save-user-permissions` Edge Function that authenticates the caller, validates the payload/role, computes the effective overrides against role defaults, and invokes the RPC.
- Updated the frontend to call this API instead of talking to Supabase directly, and to reuse it for the "Clear all overrides" action.
- Added a `signingOutRef` guard in `AuthContext` to prevent auth state change handling and session polling from firing while a sign-out is in progress, and switched `signOut` to use local-scope sign out.

### Key Changes
- **New migration** `20250901000000_stabilize_user_permissions.sql`: enforces `user_id NOT NULL`, unique `(user_id, permission_name)` constraint, recreates RLS policies (self-view, admin-manage-in-company), and adds the `replace_user_permission_overrides` RPC restricted to `service_role`.
- **New Edge Function** `supabase/functions/save-user-permissions/index.ts`: validates auth token, target user, and permission names, computes deltas vs. role defaults, and calls the RPC.
- **`src/utils/permissionSaveHelper.ts`**: replaced client-side delete/insert logic with a call to the new edge function, mapping authorization errors to a distinct error code.
- **`src/pages/settings/UserPermissions.tsx`**: updated `saveUserPermissions` call signature, fixed `toggleOverride` to correctly resolve current value against role defaults, and reworked "clear all overrides" to use the new save API plus `refreshPermissions()`.
- **`src/contexts/AuthContext.tsx`**: added `signingOutRef` to guard against re-entrant auth state changes during sign-out, skip permission polling while on the permissions settings page, and use `signOut({ scope: 'local' })`.
- **`src/integrations/supabase/types.ts`**: `user_permissions.user_id` typed as non-nullable.
- **`supabase/config.toml`**: updated project ID.
- Updated `USER_MANAGEMENT_SETUP_GUIDE.md` with deployment steps for the new function and migration.


---

<a href="https://builder.io/app/projects/f7bbb9fa02be4be1bcd7/lightning-section-aq8a3you"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://f7bbb9fa02be4be1bcd7-lightning-section-aq8a3you.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=f7bbb9fa02be4be1bcd7&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 347`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f7bbb9fa02be4be1bcd7</projectId>-->
<!--<branchName>lightning-section-aq8a3you</branchName>-->