### PR TITLE
Fix permissions page and simplify session verification

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -3,7 +3,6 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Card, CardContent } from '@/components/ui/card';
 import { Lock, ShieldAlert } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { supabase } from '@/integrations/supabase/client';
 import { hasFeature } from '@/utils/rolePermissions';
 import type { FeatureKey, UserRole } from '@/utils/rolePermissions';
 
@@ -22,35 +21,9 @@ export function ProtectedRoute({
   allowedRoles,
   requiredFeature,
 }: ProtectedRouteProps) {
-  const { isAuthenticated, loading, profile, permissions, profileReady } = useAuth();
-  const [sessionVerified, setSessionVerified] = useState(false);
-  const [verifyingSession, setVerifyingSession] = useState(false);
+  const { isAuthenticated, session, loading, profile, permissions, profileReady } = useAuth();
 
-  useEffect(() => {
-    if (isAuthenticated) {
-      setSessionVerified(true);
-      return;
-    }
-    if (loading) return;
-
-    const verifySuperbaseSession = async () => {
-      setVerifyingSession(true);
-      try {
-        const { data: { session } } = await supabase.auth.getSession();
-        if (session) {
-          setSessionVerified(true);
-        }
-      } catch {
-        // ignore
-      } finally {
-        setVerifyingSession(false);
-      }
-    };
-
-    verifySuperbaseSession();
-  }, [isAuthenticated, loading]);
-
-  if (loading || verifyingSession || (requiredFeature && isAuthenticated && !profileReady)) {
+  if (loading || (requiredFeature && isAuthenticated && !profileReady)) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
@@ -61,7 +34,7 @@ export function ProtectedRoute({
     );
   }
 
-  if (requireAuth && !isAuthenticated && !sessionVerified) {
+  if (requireAuth && !isAuthenticated && !session) {
     return fallback || (
       <div className="flex items-center justify-center min-h-[400px]">
         <Card className="w-full max-w-md text-center">

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -40,7 +40,7 @@ const getStorage = () => {
 // (tables like boqs, lcl_template_*, cash_receipts are missing). To unblock the
 // build while the types regenerate, the client is cast to `any` here. Runtime
 // behaviour is unchanged.
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
+const supabaseClient = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
   auth: {
     storage: getStorage(),
     storageKey: 'sb-auth-token',
@@ -54,3 +54,5 @@ export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABL
     },
   },
 }) as any;
+
+export { supabaseClient as supabase };

--- a/src/pages/settings/UserPermissions.tsx
+++ b/src/pages/settings/UserPermissions.tsx
@@ -87,7 +87,7 @@ export default function UserPermissions() {
         id: p.id,
         email: p.email,
         full_name: p.full_name,
-        role: p.role as UserRole,
+        role: (p.role ?? 'user') as UserRole,
         status: p.status,
         overrides: permMap[p.id] || {},
         changed: false,


### PR DESCRIPTION
### Summary
Simplifies session verification logic in `ProtectedRoute` and fixes a bug on the Settings > Permissions page caused by null user roles.

### Problem
The Permissions page was not rendering correctly, and `ProtectedRoute` relied on an extra manual Supabase session check that duplicated logic already available from `AuthContext`, adding unnecessary complexity and potential race conditions.

### Solution
`ProtectedRoute` now relies directly on the `session` value provided by `AuthContext` instead of performing its own redundant session verification call. On the Permissions page, user roles that are `null`/`undefined` now default to `'user'` to prevent invalid state when rendering permissions.

### Key Changes
- `ProtectedRoute.tsx`: Removed manual `verifySuperbaseSession` effect and related `sessionVerified`/`verifyingSession` state; now uses `session` from `useAuth()` to determine auth fallback rendering.
- `client.ts`: Renamed internal Supabase client instance to `supabaseClient` and re-exported it as `supabase` for clarity.
- `UserPermissions.tsx`: Defaulted `p.role` to `'user'` when null/undefined to avoid invalid role assignments.


---

<a href="https://builder.io/app/projects/9369dbbdadc5459e927f/archive-orb-jkf7z89z"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://9369dbbdadc5459e927f-archive-orb-jkf7z89z.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=9369dbbdadc5459e927f&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 348`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9369dbbdadc5459e927f</projectId>-->
<!--<branchName>archive-orb-jkf7z89z</branchName>-->