### PR TITLE
Link receipts to invoices and fix trailing PDF page

### DIFF
--- a/src/components/cash-receipts/EditCashReceiptModal.tsx
+++ b/src/components/cash-receipts/EditCashReceiptModal.tsx
@@ -26,6 +26,7 @@ import { useCustomers, useProducts, useTaxSettings } from '@/hooks/useDatabase';
 import { useCurrentCompany } from '@/contexts/CompanyContext';
 import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
+import { extractBoqNumberFromNotes, fetchBoqProjectTitle } from '@/utils/boqInvoiceLinkage';
 
 const PAYMENT_METHODS = [
   'Cash',
@@ -66,6 +67,7 @@ export function EditCashReceiptModal({ open, onOpenChange, onSuccess, receipt }:
   const [items, setItems] = useState<CashReceiptItem[]>([]);
   const [applyTax, setApplyTax] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [boqProjectTitle, setBoqProjectTitle] = useState<string | null>(null);
 
   const { currentCompany, isLoading: companyLoading } = useCurrentCompany();
   const { data: customers, isLoading: loadingCustomers } = useCustomers(currentCompany?.id);
@@ -104,6 +106,26 @@ export function EditCashReceiptModal({ open, onOpenChange, onSuccess, receipt }:
       setItems(mappedItems);
     }
   }, [receipt, open]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadBoqProjectTitle = async () => {
+      setBoqProjectTitle(null);
+      const invoice = receipt?.invoices;
+      if (!open || !receipt?.invoice_id || !invoice || !currentCompany?.id) return;
+
+      const boqNumber = extractBoqNumberFromNotes(invoice.notes);
+      if (!boqNumber) return;
+
+      const projectTitle = await fetchBoqProjectTitle(boqNumber, currentCompany.id);
+      if (!cancelled) setBoqProjectTitle(projectTitle);
+    };
+
+    loadBoqProjectTitle();
+    return () => {
+      cancelled = true;
+    };
+  }, [receipt, open, currentCompany?.id]);
 
   // Recalculate all items when applyTax changes
   useEffect(() => {
@@ -405,6 +427,21 @@ export function EditCashReceiptModal({ open, onOpenChange, onSuccess, receipt }:
         )}
 
         <form onSubmit={handleSubmit} className="space-y-6">
+          {receipt?.invoice_id && receipt.invoices && (
+            <div className="rounded-md border bg-muted/30 p-4 space-y-2">
+              <div className="flex justify-between gap-4 text-sm">
+                <span className="font-medium text-muted-foreground">Invoice</span>
+                <span>{receipt.invoices.invoice_number}</span>
+              </div>
+              {boqProjectTitle && (
+                <div className="flex justify-between gap-4 text-sm">
+                  <span className="font-medium text-muted-foreground">BOQ</span>
+                  <span className="text-right">{boqProjectTitle}</span>
+                </div>
+              )}
+            </div>
+          )}
+
           {/* Customer Selection */}
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">

--- a/src/components/payments/RecordPaymentModal.tsx
+++ b/src/components/payments/RecordPaymentModal.tsx
@@ -167,6 +167,7 @@ export function RecordPaymentModal({ open, onOpenChange, onSuccess, invoice }: R
         const receiptResult = await autoCreateCashReceipt({
           company_id: selectedInvoice.company_id || currentCompany!.id,
           customer_id: selectedInvoice.customer_id,
+          invoice_id: selectedInvoice.id,
           payment_date: paymentData.payment_date,
           amount: amount,
           payment_method: paymentData.payment_method,

--- a/src/pages/CashReceipts.tsx
+++ b/src/pages/CashReceipts.tsx
@@ -51,6 +51,11 @@ interface CashReceipt {
   value_tendered: number;
   change: number;
   notes?: string;
+  invoice_id?: string | null;
+  invoices?: {
+    invoice_number: string;
+    notes?: string | null;
+  } | null;
   created_at?: string;
   cash_receipt_items?: CashReceiptItem[];
 }
@@ -94,7 +99,12 @@ export default function CashReceipts() {
           value_tendered,
           change,
           notes,
+          invoice_id,
           created_at,
+          invoices:invoices!invoice_id (
+            invoice_number,
+            notes
+          ),
           customers (
             id,
             name,

--- a/src/pages/CashReceipts.tsx
+++ b/src/pages/CashReceipts.tsx
@@ -40,6 +40,7 @@ interface CashReceiptItem {
 
 interface CashReceipt {
   id: string;
+  company_id: string;
   receipt_number: string;
   customers?: {
     name: string;
@@ -88,6 +89,7 @@ export default function CashReceipts() {
 
       const sourceReceiptSelect = `
         id,
+        company_id,
         receipt_number,
         customer_id,
         receipt_date,
@@ -121,6 +123,7 @@ export default function CashReceipts() {
       `;
       const legacyReceiptSelect = `
         id,
+        company_id,
         receipt_number,
         customer_id,
         receipt_date,

--- a/src/pages/CashReceipts.tsx
+++ b/src/pages/CashReceipts.tsx
@@ -86,45 +86,84 @@ export default function CashReceipts() {
       const from = page * PAGE_SIZE;
       const to = from + PAGE_SIZE;
 
-      // Fetch receipts with items
-      const { data, error } = await supabase
-        .from('cash_receipts')
-        .select(`
+      const sourceReceiptSelect = `
+        id,
+        receipt_number,
+        customer_id,
+        receipt_date,
+        total_amount,
+        payment_method,
+        value_tendered,
+        change,
+        notes,
+        invoice_id,
+        created_at,
+        invoices:invoices!invoice_id (
+          invoice_number,
+          notes
+        ),
+        customers (
           id,
-          receipt_number,
-          customer_id,
-          receipt_date,
-          total_amount,
-          payment_method,
-          value_tendered,
-          change,
-          notes,
-          invoice_id,
-          created_at,
-          invoices:invoices!invoice_id (
-            invoice_number,
-            notes
-          ),
-          customers (
-            id,
-            name,
-            email
-          ),
-          cash_receipt_items (
-            id,
-            product_id,
-            description,
-            quantity,
-            unit_price,
-            tax_percentage,
-            tax_amount,
-            line_total,
-            unit_of_measure
-          )
-        `)
+          name,
+          email
+        ),
+        cash_receipt_items (
+          id,
+          product_id,
+          description,
+          quantity,
+          unit_price,
+          tax_percentage,
+          tax_amount,
+          line_total,
+          unit_of_measure
+        )
+      `;
+      const legacyReceiptSelect = `
+        id,
+        receipt_number,
+        customer_id,
+        receipt_date,
+        total_amount,
+        payment_method,
+        value_tendered,
+        change,
+        notes,
+        created_at,
+        customers (
+          id,
+          name,
+          email
+        ),
+        cash_receipt_items (
+          id,
+          product_id,
+          description,
+          quantity,
+          unit_price,
+          tax_percentage,
+          tax_amount,
+          line_total,
+          unit_of_measure
+        )
+      `;
+
+      let { data, error } = await supabase
+        .from('cash_receipts')
+        .select(sourceReceiptSelect)
         .eq('company_id', currentCompany.id)
         .order('receipt_date', { ascending: false })
         .range(from, to - 1);
+
+      if (error) {
+        console.warn('Receipt source details unavailable; loading receipts without invoice links:', error);
+        ({ data, error } = await supabase
+          .from('cash_receipts')
+          .select(legacyReceiptSelect)
+          .eq('company_id', currentCompany.id)
+          .order('receipt_date', { ascending: false })
+          .range(from, to - 1));
+      }
 
       if (error) {
         console.error('Supabase error details:', {

--- a/src/utils/autoCreateCashReceipt.ts
+++ b/src/utils/autoCreateCashReceipt.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 interface AutoCreateReceiptParams {
   company_id: string;
   customer_id: string;
+  invoice_id: string;
   payment_date: string;
   amount: number;
   payment_method: string;
@@ -20,6 +21,7 @@ export async function autoCreateCashReceipt(params: AutoCreateReceiptParams) {
     const {
       company_id,
       customer_id,
+      invoice_id,
       payment_date,
       amount,
       payment_method,
@@ -53,6 +55,7 @@ export async function autoCreateCashReceipt(params: AutoCreateReceiptParams) {
       .insert({
         company_id,
         customer_id,
+        invoice_id,
         receipt_number: receiptNumber,
         receipt_date: payment_date,
         total_amount: amount,

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -3356,7 +3356,7 @@ export const generatePDF = async (data: DocumentData) => {
         }
 
         body.receipt-document .page:last-of-type {
-          padding-bottom: 15mm;
+          padding-bottom: 0;
           margin-bottom: 0;
           page-break-after: auto;
         }

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -4650,6 +4650,12 @@ export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails) => {
 
 // Function for generating cash receipt PDF
 export const downloadCashReceiptPDF = async (receipt: any, company?: CompanyDetails) => {
+  const projectTitle = receipt.project_title || (
+    receipt.invoices?.invoice_number && receipt.company_id
+      ? await getProjectTitleFromInvoice(receipt.invoices, receipt.company_id)
+      : null
+  );
+
   // Format items from receipt
   const items = (receipt.cash_receipt_items || []).map((item: any) => ({
     description: item.description,
@@ -4678,6 +4684,7 @@ export const downloadCashReceiptPDF = async (receipt: any, company?: CompanyDeta
       city: receipt.customers?.city,
       country: receipt.customers?.country,
     },
+    project_title: projectTitle || undefined,
     items: items.length > 0 ? items : [
       {
         description: 'Payment Received',

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -323,32 +323,39 @@ const convertHTMLToPDFAndDownload = async (htmlContent: string, filename: string
         continue;
       }
 
-      // Crop and add canvas to PDF in page-sized chunks
+      // Fit receipt overflow onto one page instead of creating a trailing page.
       const canvasW = pageCanvas.width;
       const canvasH = pageCanvas.height;
       const pxPerMm = canvasW / pageWidth;
-      let yPxOffset = 0;
 
-      while (yPxOffset < canvasH) {
-        if (!isFirstPage) {
-          pdf.addPage();
-        }
+      if (data.type === 'receipt') {
+        if (!isFirstPage) pdf.addPage();
         isFirstPage = false;
+        const pageImgData = pageCanvas.toDataURL('image/jpeg', PDF_IMAGE_QUALITY);
+        pdf.addImage(pageImgData, 'JPEG', 0, 0, pageWidth, pageHeight);
+      } else {
+        let yPxOffset = 0;
+        while (yPxOffset < canvasH) {
+          if (!isFirstPage) {
+            pdf.addPage();
+          }
+          isFirstPage = false;
 
-        const capturePx = Math.min(canvasH - yPxOffset, Math.round(pageHeight * pxPerMm));
-        const captureHmm = capturePx / pxPerMm;
+          const capturePx = Math.min(canvasH - yPxOffset, Math.round(pageHeight * pxPerMm));
+          const captureHmm = capturePx / pxPerMm;
 
-        const tempCanvas = document.createElement('canvas');
-        tempCanvas.width = canvasW;
-        tempCanvas.height = capturePx;
-        const tempCtx = tempCanvas.getContext('2d');
-        if (tempCtx) {
-          tempCtx.drawImage(pageCanvas, 0, yPxOffset, canvasW, capturePx, 0, 0, canvasW, capturePx);
+          const tempCanvas = document.createElement('canvas');
+          tempCanvas.width = canvasW;
+          tempCanvas.height = capturePx;
+          const tempCtx = tempCanvas.getContext('2d');
+          if (tempCtx) {
+            tempCtx.drawImage(pageCanvas, 0, yPxOffset, canvasW, capturePx, 0, 0, canvasW, capturePx);
+          }
+          const chunkImgData = tempCanvas.toDataURL('image/jpeg', PDF_IMAGE_QUALITY);
+
+          pdf.addImage(chunkImgData, 'JPEG', 0, 0, pageWidth, captureHmm);
+          yPxOffset += capturePx;
         }
-        const chunkImgData = tempCanvas.toDataURL('image/jpeg', PDF_IMAGE_QUALITY);
-
-        pdf.addImage(chunkImgData, 'JPEG', 0, 0, pageWidth, captureHmm);
-        yPxOffset += capturePx;
       }
 
       progressStep += 1;

--- a/supabase/migrations/20260804000000_add_invoice_id_to_cash_receipts.sql
+++ b/supabase/migrations/20260804000000_add_invoice_id_to_cash_receipts.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.cash_receipts
+  ADD COLUMN IF NOT EXISTS invoice_id UUID REFERENCES public.invoices(id);
+
+CREATE INDEX IF NOT EXISTS cash_receipts_invoice_id_idx
+  ON public.cash_receipts(invoice_id);


### PR DESCRIPTION
### Summary
Links cash receipts to their originating invoice (and BOQ project title where applicable) and fixes a trailing blank page in generated receipt PDFs.

### Problem
The receipt edit modal did not show the invoice or BOQ/project title when a receipt was generated from an invoice created from a BOQ, making it hard to trace context. Additionally, the generated receipt PDF included an unwanted trailing blank page.

### Solution
- Added an `invoice_id` column on `cash_receipts` to establish a direct link between receipts and invoices, with backfill support via `autoCreateCashReceipt`.
- Updated the Edit Cash Receipt modal to look up the linked invoice and, if the invoice references a BOQ, resolve and display the BOQ project title.
- Updated the Cash Receipts list query to fetch invoice details, falling back to a legacy query if the new join is unavailable (e.g. before migration).
- Reworked receipt PDF rendering to place receipt content on a single page instead of chunking across pages, removing the trailing blank page, and adjusted receipt page styling accordingly.
- Propagated `project_title` into the cash receipt PDF payload, resolving it from the linked invoice when not explicitly provided.

### Key Changes
- **`supabase/migrations/20260804000000_add_invoice_id_to_cash_receipts.sql`**: New migration adding `invoice_id` FK column and index to `cash_receipts`.
- **`src/utils/autoCreateCashReceipt.ts`**: Accepts and persists `invoice_id` when auto-creating receipts.
- **`src/components/payments/RecordPaymentModal.tsx`**: Passes `invoice_id` when auto-creating a cash receipt from a payment.
- **`src/components/cash-receipts/EditCashReceiptModal.tsx`**: Fetches and displays linked invoice number and BOQ project title using `extractBoqNumberFromNotes` / `fetchBoqProjectTitle` from `boqInvoiceLinkage`.
- **`src/pages/CashReceipts.tsx`**: Updated `CashReceipt` interface and Supabase query to include `invoice_id`/`invoices` join, with a legacy fallback query on error.
- **`src/utils/pdfGenerator.ts`**: 
  - Receipts now render on a single page (no chunked pagination) to eliminate trailing blank pages.
  - Removed bottom padding on the last receipt page.
  - `downloadCashReceiptPDF` resolves `project_title` from the linked invoice when not already present on the receipt.


---

<a href="https://builder.io/app/projects/10f78979c06c463292be/prairie-craft-9sjr3rla"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://10f78979c06c463292be-prairie-craft-9sjr3rla.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=10f78979c06c463292be&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 349`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>10f78979c06c463292be</projectId>-->
<!--<branchName>prairie-craft-9sjr3rla</branchName>-->