### PR TITLE
Sort payments/receipts by date and add project titles to receipts

### DIFF
--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -922,8 +922,9 @@ export const usePayments = (companyId?: string) => {
             updated_at
           `)
           .eq('company_id', companyId)
-          .order('created_at', { ascending: true })
-          .order('id', { ascending: true });
+          .order('payment_date', { ascending: false })
+          .order('created_at', { ascending: false })
+          .order('id', { ascending: false });
 
         const { data: payments, error: paymentsError } = await query;
 

--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { parseErrorMessage } from '@/utils/errorHelpers';
 import { RLSPolicyError } from '@/utils/RLSError';
 import { ensureCompanyImageColumns, ensureQuantityColumnsAreDecimal } from '@/utils/ensureDatabaseColumns';
+import { extractBoqNumberFromNotes, fetchBoqProjectTitle } from '@/utils/boqInvoiceLinkage';
 
 // Types
 export interface Company {
@@ -999,7 +1000,7 @@ export const usePayments = (companyId?: string) => {
               // Try to fetch invoices by their IDs
               let { data: invoiceData, error: invoiceError } = await supabase
                 .from('invoices')
-                .select('id, invoice_number, project_title, total_amount, paid_amount, balance_due, company_id')
+                .select('id, invoice_number, notes, total_amount, paid_amount, balance_due, company_id')
                 .in('id', validInvoiceIds);
 
               console.log('Invoice fetch result (specific IDs):', {
@@ -1022,7 +1023,7 @@ export const usePayments = (companyId?: string) => {
                 // Fallback: Fetch all invoices for the company
                 const { data: allInvoices, error: allInvoicesError } = await supabase
                   .from('invoices')
-                  .select('id, invoice_number, project_title, total_amount, paid_amount, balance_due, company_id')
+                  .select('id, invoice_number, notes, total_amount, paid_amount, balance_due, company_id')
                   .eq('company_id', companyId);
 
                 console.log('Fallback invoice fetch result (all for company):', {
@@ -1043,6 +1044,20 @@ export const usePayments = (companyId?: string) => {
                   });
                 }
               }
+
+              const boqNumbers = [...new Set(
+                [...invoiceMap.values()]
+                  .map(invoice => extractBoqNumberFromNotes(invoice.notes))
+                  .filter((boqNumber): boqNumber is string => Boolean(boqNumber))
+              )];
+              const boqProjectTitles = new Map<string, string | null>();
+              await Promise.all(boqNumbers.map(async boqNumber => {
+                boqProjectTitles.set(boqNumber, await fetchBoqProjectTitle(boqNumber, companyId));
+              }));
+              invoiceMap.forEach(invoice => {
+                const boqNumber = extractBoqNumberFromNotes(invoice.notes);
+                invoice.project_title = boqNumber ? boqProjectTitles.get(boqNumber) || null : null;
+              });
 
               // Log which invoice IDs were not found
               const notFoundIds = validInvoiceIds.filter(id => !invoiceMap.has(id));

--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -999,7 +999,7 @@ export const usePayments = (companyId?: string) => {
               // Try to fetch invoices by their IDs
               let { data: invoiceData, error: invoiceError } = await supabase
                 .from('invoices')
-                .select('id, invoice_number, total_amount, paid_amount, balance_due, company_id')
+                .select('id, invoice_number, project_title, total_amount, paid_amount, balance_due, company_id')
                 .in('id', validInvoiceIds);
 
               console.log('Invoice fetch result (specific IDs):', {
@@ -1022,7 +1022,7 @@ export const usePayments = (companyId?: string) => {
                 // Fallback: Fetch all invoices for the company
                 const { data: allInvoices, error: allInvoicesError } = await supabase
                   .from('invoices')
-                  .select('id, invoice_number, total_amount, paid_amount, balance_due, company_id')
+                  .select('id, invoice_number, project_title, total_amount, paid_amount, balance_due, company_id')
                   .eq('company_id', companyId);
 
                 console.log('Fallback invoice fetch result (all for company):', {
@@ -1073,6 +1073,7 @@ export const usePayments = (companyId?: string) => {
           allocationsMap.get(allocation.payment_id).push({
             id: allocation.id,
             invoice_number: invoice?.invoice_number || 'N/A',
+            project_title: invoice?.project_title || null,
             allocated_amount: Number(allocation.amount_allocated || 0),
             invoice_total: Number(invoice?.total_amount || 0),
             paid_amount: Number(invoice?.paid_amount || 0),

--- a/src/pages/CashReceipts.tsx
+++ b/src/pages/CashReceipts.tsx
@@ -53,8 +53,10 @@ interface CashReceipt {
   change: number;
   notes?: string;
   invoice_id?: string | null;
+  project_title?: string | null;
   invoices?: {
     invoice_number: string;
+    project_title?: string | null;
     notes?: string | null;
   } | null;
   created_at?: string;
@@ -102,6 +104,7 @@ export default function CashReceipts() {
         created_at,
         invoices:invoices!invoice_id (
           invoice_number,
+          project_title,
           notes
         ),
         customers (

--- a/src/pages/CashReceipts.tsx
+++ b/src/pages/CashReceipts.tsx
@@ -156,6 +156,7 @@ export default function CashReceipts() {
         .select(sourceReceiptSelect)
         .eq('company_id', currentCompany.id)
         .order('receipt_date', { ascending: false })
+        .order('created_at', { ascending: false })
         .range(from, to - 1);
 
       if (error) {
@@ -165,6 +166,7 @@ export default function CashReceipts() {
           .select(legacyReceiptSelect)
           .eq('company_id', currentCompany.id)
           .order('receipt_date', { ascending: false })
+          .order('created_at', { ascending: false })
           .range(from, to - 1));
       }
 

--- a/src/pages/CashReceipts.tsx
+++ b/src/pages/CashReceipts.tsx
@@ -104,7 +104,6 @@ export default function CashReceipts() {
         created_at,
         invoices:invoices!invoice_id (
           invoice_number,
-          project_title,
           notes
         ),
         customers (
@@ -135,7 +134,12 @@ export default function CashReceipts() {
         value_tendered,
         change,
         notes,
+        invoice_id,
         created_at,
+        invoices:invoices!invoice_id (
+          invoice_number,
+          notes
+        ),
         customers (
           id,
           name,

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -275,7 +275,17 @@ export default function Payments() {
 
   // Removed inline PDF generation function - now using utility function
 
-  const filteredPayments = payments.filter(payment => {
+  const sortedPayments = [...payments].sort((a, b) => {
+    const paymentDateDifference = new Date(b.payment_date).getTime() - new Date(a.payment_date).getTime();
+    if (paymentDateDifference !== 0) return paymentDateDifference;
+
+    const createdAtDifference = new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
+    if (createdAtDifference !== 0) return createdAtDifference;
+
+    return b.id.localeCompare(a.id);
+  });
+
+  const filteredPayments = sortedPayments.filter(payment => {
     const matchesSearch =
       (payment.customers?.name?.toLowerCase().includes(searchTerm.toLowerCase()) ?? false) ||
       (payment.payment_number?.toLowerCase().includes(searchTerm.toLowerCase()) ?? false) ||

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -214,7 +214,7 @@ export default function Payments() {
     }
   };
 
-  const handleDownloadReceipt = (payment: Payment) => {
+  const handleDownloadReceipt = async (payment: Payment) => {
     try {
       // Debug: Log the payment data
       console.log('Payment data for receipt:', {
@@ -265,7 +265,7 @@ export default function Payments() {
         company_services: currentCompany.company_services
       } : undefined;
 
-      generatePaymentReceiptPDF(enrichedPayment, companyDetails);
+      await generatePaymentReceiptPDF(enrichedPayment, companyDetails);
       toast.success(`Receipt downloaded for payment ${payment.payment_number}`);
     } catch (error) {
       console.error('Error downloading receipt:', error);

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -71,6 +71,7 @@ interface Payment {
     balance_due?: number;
     allocation_created_at?: string | null;
     invoice_id?: string | null;
+    project_title?: string | null;
   }[];
 }
 

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -4482,6 +4482,12 @@ export const generatePaymentReceiptPDF = async (payment: any, company?: CompanyD
     };
   });
 
+  const projectTitles = [...new Set(
+    invoicesToDisplay
+      .map((invoice: any) => invoice.project_title)
+      .filter((title: string | null | undefined): title is string => Boolean(title))
+  )];
+
   const documentData: DocumentData = {
     type: 'receipt', // Use receipt type for payment receipts
     number: payment.number || payment.payment_number || `REC-${Date.now()}`,
@@ -4492,6 +4498,7 @@ export const generatePaymentReceiptPDF = async (payment: any, company?: CompanyD
       email: payment.customers?.email,
       phone: payment.customers?.phone,
     },
+    project_title: projectTitles.length === 1 ? projectTitles[0] : undefined,
     total_amount: typeof payment.amount === 'string' ?
       parseFloat(payment.amount.replace('$', '').replace(',', '')) :
       payment.amount,

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -222,7 +222,7 @@ const addCanvasToPDF = async (pdf: jsPDF, canvas: HTMLCanvasElement, pageWidth: 
 };
 
 // Helper function to convert HTML to PDF and auto-download
-const convertHTMLToPDFAndDownload = async (htmlContent: string, filename: string) => {
+const convertHTMLToPDFAndDownload = async (htmlContent: string, filename: string, documentType: DocumentData['type']) => {
   let wrapper: HTMLElement | null = null;
   let progressStep = 0;
   let progressTotal = 1;
@@ -328,7 +328,7 @@ const convertHTMLToPDFAndDownload = async (htmlContent: string, filename: string
       const canvasH = pageCanvas.height;
       const pxPerMm = canvasW / pageWidth;
 
-      if (data.type === 'receipt') {
+      if (documentType === 'receipt') {
         if (!isFirstPage) pdf.addPage();
         isFirstPage = false;
         const pageImgData = pageCanvas.toDataURL('image/jpeg', PDF_IMAGE_QUALITY);
@@ -2892,7 +2892,7 @@ export const generatePDF = async (data: DocumentData) => {
     } else {
       filename = `${data.number}.pdf`;
     }
-    await convertHTMLToPDFAndDownload(htmlContentWithSections, filename);
+    await convertHTMLToPDFAndDownload(htmlContentWithSections, filename, data.type);
   }
 
   // Fallback generic document HTML (existing template)
@@ -3982,7 +3982,7 @@ export const generatePDF = async (data: DocumentData) => {
   } else {
     fallbackFilename = `${data.number}.pdf`;
   }
-  await convertHTMLToPDFAndDownload(htmlContent, fallbackFilename);
+  await convertHTMLToPDFAndDownload(htmlContent, fallbackFilename, data.type);
 };
 
 // Specific function for invoice PDF generation

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -4659,7 +4659,7 @@ export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails) => {
 
 // Function for generating cash receipt PDF
 export const downloadCashReceiptPDF = async (receipt: any, company?: CompanyDetails) => {
-  const projectTitle = receipt.project_title || (
+  const projectTitle = receipt.project_title || receipt.invoices?.project_title || (
     receipt.invoices?.invoice_number && receipt.company_id
       ? await getProjectTitleFromInvoice(receipt.invoices, receipt.company_id)
       : null

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -3754,7 +3754,7 @@ export const generatePDF = async (data: DocumentData) => {
                 ${(data.items as any[]).map((item: any, index: number) => `
                 <tr style="border: 1px solid #ddd;">
                   <td style="padding: 8px; text-align: left; border: 1px solid #ddd; font-size: 10px;">${index + 1}</td>
-                  <td style="padding: 8px; text-align: left; border: 1px solid #ddd; font-size: 10px;">Invoice ${item.invoice_number && item.invoice_number !== 'N/A' ? item.invoice_number : 'Unknown'}</td>
+                  <td style="padding: 8px; text-align: left; border: 1px solid #ddd; font-size: 10px;">Invoice ${item.invoice_number && item.invoice_number !== 'N/A' ? item.invoice_number : 'Unknown'}${item.project_title ? `<br><span style="font-size: 9px; color: #555;">${item.project_title}</span>` : ''}</td>
                   <td style="padding: 8px; text-align: right; border: 1px solid #ddd; font-size: 10px; font-weight: 600;">${formatCurrency((item as any).allocated_amount || 0)}</td>
                 </tr>
                 `).join('')}
@@ -4462,6 +4462,7 @@ export const generatePaymentReceiptPDF = async (payment: any, company?: CompanyD
   const invoiceParticulars = payment.payment_allocations && payment.payment_allocations.length > 0
     ? payment.payment_allocations.map((alloc: any) => ({
         invoice_number: alloc.invoice_number || 'N/A',
+        project_title: alloc.project_title || '',
         invoice_total: alloc.invoice_total || 0,
         allocated_amount: alloc.allocated_amount || 0,
         // Use enriched previous_balance if available, otherwise calculate
@@ -4497,6 +4498,7 @@ export const generatePaymentReceiptPDF = async (payment: any, company?: CompanyD
     // Add invoice particulars and balance information
     items: invoicesToDisplay.map((inv: any) => ({
       description: `Invoice ${inv.invoice_number}`,
+      project_title: inv.project_title,
       quantity: 1,
       unit_price: 0,
       tax_percentage: 0,


### PR DESCRIPTION
### Summary
Sorts payments and cash receipts by most recent first and propagates project titles into payment/cash receipt PDFs so linked invoices show their BOQ project context.

### Problem
Payments and receipts were listed in ascending order (oldest first), making it hard to find recent transactions. Additionally, payment and cash receipts did not display the associated project title, even though invoices could be linked to BOQ projects.

### Solution
Updated the database queries and in-memory sorts to order payments and receipts by date descending (newest first), with tie-breakers on creation time and ID. Added logic to resolve project titles from invoice notes (via BOQ number extraction) and thread that data through to the payment receipt PDF and cash receipt PDF generation.

### Key Changes
- `useDatabase.ts`: `usePayments` now orders by `payment_date`, `created_at`, and `id` descending; fetches invoice `notes`, extracts BOQ numbers, resolves project titles via `fetchBoqProjectTitle`, and attaches `project_title` to invoices and payment allocations.
- `Payments.tsx`: Added a `sortedPayments` computation (payment date → created_at → id, all descending) applied before filtering; `handleDownloadReceipt` now awaits the async `generatePaymentReceiptPDF` call; added `project_title` to the payment allocation type.
- `CashReceipts.tsx`: Query now selects `invoice_id` and joined `invoices(invoice_number, notes)`, adds a secondary `created_at` descending sort after `receipt_date`, and adds `project_title` fields to the `CashReceipt` interface.
- `pdfGenerator.ts`:
  - `convertHTMLToPDFAndDownload` now takes an explicit `documentType` parameter instead of relying on closure-captured `data.type`.
  - `generatePaymentReceiptPDF` computes a de-duplicated set of project titles from allocations/invoices, sets a single `project_title` on the document when unambiguous, and passes `project_title` per invoice item to render alongside the invoice number.
  - `downloadCashReceiptPDF` now falls back to `receipt.invoices?.project_title` when resolving the project title.


---

<a href="https://builder.io/app/projects/c0cd3b1932d748aabb0f/lightning-ship-rs3mdxsr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://c0cd3b1932d748aabb0f-lightning-ship-rs3mdxsr.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=c0cd3b1932d748aabb0f&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 350`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c0cd3b1932d748aabb0f</projectId>-->
<!--<branchName>lightning-ship-rs3mdxsr</branchName>-->