### PR TITLE
Fix unknown invoice number on standalone cash receipt PDFs

### DIFF
--- a/src/utils/cashReceiptItems.test.ts
+++ b/src/utils/cashReceiptItems.test.ts
@@ -1,0 +1,21 @@
+import { mapCashReceiptItems } from './pdfGenerator';
+
+const receiptItem = {
+  description: 'Payment received',
+  quantity: 1,
+  unit_price: 80000,
+  tax_percentage: 0,
+  tax_amount: 0,
+  line_total: 80000,
+};
+
+const linkedItems = mapCashReceiptItems({
+  invoices: { invoice_number: 'INV-179' },
+  cash_receipt_items: [receiptItem],
+});
+assert.equal(linkedItems[0].invoice_number, 'INV-179');
+
+const historicalItems = mapCashReceiptItems({
+  cash_receipt_items: [receiptItem],
+});
+assert.equal(historicalItems[0].invoice_number, undefined);

--- a/src/utils/cashReceiptItems.test.ts
+++ b/src/utils/cashReceiptItems.test.ts
@@ -17,5 +17,10 @@ assert.equal(linkedItems[0].invoice_number, 'INV-179');
 
 const historicalItems = mapCashReceiptItems({
   cash_receipt_items: [receiptItem],
+}, 'INV-179');
+assert.equal(historicalItems[0].invoice_number, 'INV-179');
+
+const unlinkedItems = mapCashReceiptItems({
+  cash_receipt_items: [receiptItem],
 });
-assert.equal(historicalItems[0].invoice_number, undefined);
+assert.equal(unlinkedItems[0].invoice_number, undefined);

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -4664,6 +4664,18 @@ export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails) => {
   return generatePDF(documentData);
 };
 
+export const mapCashReceiptItems = (receipt: any) =>
+  (receipt.cash_receipt_items || []).map((item: any) => ({
+    description: item.description,
+    quantity: item.quantity,
+    unit_price: item.unit_price,
+    tax_percentage: item.tax_percentage || 0,
+    tax_amount: item.tax_amount || 0,
+    tax_inclusive: false,
+    line_total: item.line_total,
+    invoice_number: receipt.invoices?.invoice_number,
+  }));
+
 // Function for generating cash receipt PDF
 export const downloadCashReceiptPDF = async (receipt: any, company?: CompanyDetails) => {
   const projectTitle = receipt.project_title || receipt.invoices?.project_title || (
@@ -4672,16 +4684,7 @@ export const downloadCashReceiptPDF = async (receipt: any, company?: CompanyDeta
       : null
   );
 
-  // Format items from receipt
-  const items = (receipt.cash_receipt_items || []).map((item: any) => ({
-    description: item.description,
-    quantity: item.quantity,
-    unit_price: item.unit_price,
-    tax_percentage: item.tax_percentage || 0,
-    tax_amount: item.tax_amount || 0,
-    tax_inclusive: false,
-    line_total: item.line_total,
-  }));
+  const items = mapCashReceiptItems(receipt);
 
   // Calculate totals
   const subtotal = items.reduce((sum: number, item: any) => sum + (item.quantity * item.unit_price), 0);

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -3754,7 +3754,7 @@ export const generatePDF = async (data: DocumentData) => {
                 ${(data.items as any[]).map((item: any, index: number) => `
                 <tr style="border: 1px solid #ddd;">
                   <td style="padding: 8px; text-align: left; border: 1px solid #ddd; font-size: 10px;">${index + 1}</td>
-                  <td style="padding: 8px; text-align: left; border: 1px solid #ddd; font-size: 10px;">Invoice ${item.invoice_number && item.invoice_number !== 'N/A' ? item.invoice_number : 'Unknown'}${item.project_title ? `<br><span style="font-size: 9px; color: #555;">${item.project_title}</span>` : ''}</td>
+                  <td style="padding: 8px; text-align: left; border: 1px solid #ddd; font-size: 10px;">${item.invoice_number && item.invoice_number !== 'N/A' ? `Invoice ${item.invoice_number}` : (item.description && item.description !== 'Invoice Unknown' && item.description !== 'Unknown Invoice' ? item.description : 'Payment Received')}${item.project_title ? `<br><span style="font-size: 9px; color: #555;">${item.project_title}</span>` : ''}</td>
                   <td style="padding: 8px; text-align: right; border: 1px solid #ddd; font-size: 10px; font-weight: 600;">${formatCurrency((item as any).allocated_amount || 0)}</td>
                 </tr>
                 `).join('')}

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -4664,7 +4664,38 @@ export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails) => {
   return generatePDF(documentData);
 };
 
-export const mapCashReceiptItems = (receipt: any) =>
+const findHistoricalReceiptInvoiceNumber = async (receipt: any) => {
+  if (receipt.invoices?.invoice_number || !receipt.company_id || !receipt.customer_id || !receipt.receipt_date) {
+    return undefined;
+  }
+
+  const { data: matchingPayments, error: paymentsError } = await supabase
+    .from('payments')
+    .select('id')
+    .eq('company_id', receipt.company_id)
+    .eq('customer_id', receipt.customer_id)
+    .eq('payment_date', receipt.receipt_date)
+    .eq('amount', receipt.total_amount);
+
+  if (paymentsError || matchingPayments?.length !== 1) return undefined;
+
+  const { data: allocations, error: allocationsError } = await supabase
+    .from('payment_allocations')
+    .select('invoice_id')
+    .eq('payment_id', matchingPayments[0].id);
+
+  if (allocationsError || allocations?.length !== 1 || !allocations[0].invoice_id) return undefined;
+
+  const { data: invoice, error: invoiceError } = await supabase
+    .from('invoices')
+    .select('invoice_number')
+    .eq('id', allocations[0].invoice_id)
+    .maybeSingle();
+
+  return invoiceError ? undefined : invoice?.invoice_number;
+};
+
+export const mapCashReceiptItems = (receipt: any, invoiceNumber?: string) =>
   (receipt.cash_receipt_items || []).map((item: any) => ({
     description: item.description,
     quantity: item.quantity,
@@ -4673,7 +4704,7 @@ export const mapCashReceiptItems = (receipt: any) =>
     tax_amount: item.tax_amount || 0,
     tax_inclusive: false,
     line_total: item.line_total,
-    invoice_number: receipt.invoices?.invoice_number,
+    invoice_number: invoiceNumber || receipt.invoices?.invoice_number,
   }));
 
 // Function for generating cash receipt PDF
@@ -4684,7 +4715,8 @@ export const downloadCashReceiptPDF = async (receipt: any, company?: CompanyDeta
       : null
   );
 
-  const items = mapCashReceiptItems(receipt);
+  const invoiceNumber = await findHistoricalReceiptInvoiceNumber(receipt);
+  const items = mapCashReceiptItems(receipt, invoiceNumber);
 
   // Calculate totals
   const subtotal = items.reduce((sum: number, item: any) => sum + (item.quantity * item.unit_price), 0);


### PR DESCRIPTION
### Summary
Fixes standalone cash receipt PDFs showing "Invoice Unknown" by resolving the linked invoice number through payment records, and improves the particulars line fallback text.

### Problem
Old standalone cash receipts displayed the invoice number as "Unknown", while receipts generated from the payments page correctly showed the invoice number. This was because standalone receipts didn't always have a directly linked invoice record to pull the invoice number from.

### Solution
Added a lookup that, when a receipt has no directly linked invoice, tries to find a matching historical payment (by company, customer, date, and amount) and traces it through payment allocations to the actual invoice number. This resolved invoice number is then passed into the item mapping used for the PDF, with an improved fallback label when no invoice number can be found.

### Key Changes
- Added `findHistoricalReceiptInvoiceNumber` helper in `pdfGenerator.ts` that queries `payments` and `payment_allocations` tables to resolve an invoice number for receipts lacking a direct invoice link.
- Extracted item mapping logic into a new exported `mapCashReceiptItems` function that accepts an optional `invoiceNumber` and attaches it to each item.
- Updated `downloadCashReceiptPDF` to call `findHistoricalReceiptInvoiceNumber` and pass the result into `mapCashReceiptItems`.
- Updated the invoice particulars rendering logic in the PDF template to show "Invoice {number}" when available, otherwise fall back to the item description or "Payment Received" instead of "Unknown".
- Added `src/utils/cashReceiptItems.test.ts` covering linked, historical, and unlinked invoice number scenarios for `mapCashReceiptItems`.

---

<a href="https://builder.io/app/projects/83f7e4ac4e414d588cbe/hidden-tie-dv9fqrd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://83f7e4ac4e414d588cbe-hidden-tie-dv9fqrd5.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=83f7e4ac4e414d588cbe&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 351`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>83f7e4ac4e414d588cbe</projectId>-->
<!--<branchName>hidden-tie-dv9fqrd5</branchName>-->