### PR TITLE
Fix SPA routing on Render and add lazy-load retry with error boundary

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: layons-erpss
+    runtime: static
+    buildCommand: npm ci && npm run build
+    staticPublishPath: dist
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import PDFProgressDialog from "@/components/ui/PDFProgressDialog";
 import { Routes, Route } from "react-router-dom";
-import { useEffect, useState, Component, ReactNode, ErrorInfo } from "react";
+import { useEffect, useState, Component, ReactNode, ErrorInfo, ComponentType, lazy, Suspense } from "react";
 import { Layout } from "@/components/layout/Layout";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { useCurrentCompany } from "@/contexts/CompanyContext";
@@ -18,47 +18,66 @@ import { ensureRLSPolicies } from "@/utils/ensureRLSPolicies";
 import { ensureCompanyImageColumns } from "@/utils/ensureDatabaseColumns";
 import { ensureDatabaseIndexes } from "@/utils/ensureDatabaseIndexes";
 
-// Lazy load the page components to reduce initial bundle size and startup time
-import { lazy, Suspense } from "react";
+const lazyWithRetry = <T extends ComponentType<unknown>>(
+  importer: () => Promise<{ default: T }>,
+  retries = 2,
+) =>
+  lazy(async () => {
+    let lastError: unknown;
 
-const Index = lazy(() => import("./pages/Index"));
-const Quotations = lazy(() => import("./pages/Quotations"));
-const Invoices = lazy(() => import("./pages/Invoices"));
-const Payments = lazy(() => import("./pages/Payments"));
-const Inventory = lazy(() => import("./pages/Inventory"));
-const Customers = lazy(() => import("./pages/Customers"));
-const DeliveryNotes = lazy(() => import("./pages/DeliveryNotes"));
-const Proforma = lazy(() => import("./pages/Proforma"));
-const ReportsOverview = lazy(() => import("./pages/reports/ReportsOverview"));
-const SalesReports = lazy(() => import("./pages/reports/SalesReports"));
-const InventoryReports = lazy(() => import("./pages/reports/InventoryReports"));
-const StatementOfAccounts = lazy(() => import("./pages/reports/StatementOfAccounts"));
-const CompanySettings = lazy(() => import("./pages/settings/CompanySettings"));
-const UserManagement = lazy(() => import("./pages/settings/UserManagement"));
-const UserPermissions = lazy(() => import("./pages/settings/UserPermissions"));
-const UnitsSettings = lazy(() => import("./pages/settings/Units"));
-const UnitsNormalize = lazy(() => import("./pages/settings/UnitsNormalize"));
-const RemittanceAdvice = lazy(() => import("./pages/RemittanceAdvice"));
-const LPOs = lazy(() => import("./pages/LPOs"));
-const BOQs = lazy(() => import("./pages/BOQs"));
-const FixedBOQ = lazy(() => import("./pages/FixedBOQ"));
-const FixedBOQHierarchical = lazy(() => import("./pages/FixedBOQHierarchical"));
-const LCLTemplate = lazy(() => import("./pages/LCLTemplate"));
-const LCLBOQList = lazy(() => import("./pages/LCLBOQList"));
-const CreditNotes = lazy(() => import("./pages/CreditNotes"));
-const CashReceipts = lazy(() => import("./pages/CashReceipts"));
-const NotFound = lazy(() => import("./pages/NotFound"));
-const PaymentSynchronizationPage = lazy(() => import("./pages/PaymentSynchronization"));
-const OptimizedInventory = lazy(() => import("./pages/OptimizedInventory"));
-const PerformanceOptimizerPage = lazy(() => import("./pages/PerformanceOptimizerPage"));
-const OptimizedCustomers = lazy(() => import("./pages/OptimizedCustomers"));
-const CustomerPerformanceOptimizerPage = lazy(() => import("./pages/CustomerPerformanceOptimizerPage"));
-const AuditLogs = lazy(() => import("./pages/AuditLogs"));
-const DatabaseFix = lazy(() => import("./pages/DatabaseFix"));
-const CompanyIdConsolidation = lazy(() => import("./pages/CompanyIdConsolidation"));
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+      try {
+        return await importer();
+      } catch (error) {
+        lastError = error;
+        if (attempt < retries) {
+          await new Promise(resolve => setTimeout(resolve, 300 * (attempt + 1)));
+        }
+      }
+    }
+
+    throw lastError;
+  });
+
+// Lazy load the page components to reduce initial bundle size and startup time
+const Index = lazyWithRetry(() => import("./pages/Index"));
+const Quotations = lazyWithRetry(() => import("./pages/Quotations"));
+const Invoices = lazyWithRetry(() => import("./pages/Invoices"));
+const Payments = lazyWithRetry(() => import("./pages/Payments"));
+const Inventory = lazyWithRetry(() => import("./pages/Inventory"));
+const Customers = lazyWithRetry(() => import("./pages/Customers"));
+const DeliveryNotes = lazyWithRetry(() => import("./pages/DeliveryNotes"));
+const Proforma = lazyWithRetry(() => import("./pages/Proforma"));
+const ReportsOverview = lazyWithRetry(() => import("./pages/reports/ReportsOverview"));
+const SalesReports = lazyWithRetry(() => import("./pages/reports/SalesReports"));
+const InventoryReports = lazyWithRetry(() => import("./pages/reports/InventoryReports"));
+const StatementOfAccounts = lazyWithRetry(() => import("./pages/reports/StatementOfAccounts"));
+const CompanySettings = lazyWithRetry(() => import("./pages/settings/CompanySettings"));
+const UserManagement = lazyWithRetry(() => import("./pages/settings/UserManagement"));
+const UserPermissions = lazyWithRetry(() => import("./pages/settings/UserPermissions"));
+const UnitsSettings = lazyWithRetry(() => import("./pages/settings/Units"));
+const UnitsNormalize = lazyWithRetry(() => import("./pages/settings/UnitsNormalize"));
+const RemittanceAdvice = lazyWithRetry(() => import("./pages/RemittanceAdvice"));
+const LPOs = lazyWithRetry(() => import("./pages/LPOs"));
+const BOQs = lazyWithRetry(() => import("./pages/BOQs"));
+const FixedBOQ = lazyWithRetry(() => import("./pages/FixedBOQ"));
+const FixedBOQHierarchical = lazyWithRetry(() => import("./pages/FixedBOQHierarchical"));
+const LCLTemplate = lazyWithRetry(() => import("./pages/LCLTemplate"));
+const LCLBOQList = lazyWithRetry(() => import("./pages/LCLBOQList"));
+const CreditNotes = lazyWithRetry(() => import("./pages/CreditNotes"));
+const CashReceipts = lazyWithRetry(() => import("./pages/CashReceipts"));
+const NotFound = lazyWithRetry(() => import("./pages/NotFound"));
+const PaymentSynchronizationPage = lazyWithRetry(() => import("./pages/PaymentSynchronization"));
+const OptimizedInventory = lazyWithRetry(() => import("./pages/OptimizedInventory"));
+const PerformanceOptimizerPage = lazyWithRetry(() => import("./pages/PerformanceOptimizerPage"));
+const OptimizedCustomers = lazyWithRetry(() => import("./pages/OptimizedCustomers"));
+const CustomerPerformanceOptimizerPage = lazyWithRetry(() => import("./pages/CustomerPerformanceOptimizerPage"));
+const AuditLogs = lazyWithRetry(() => import("./pages/AuditLogs"));
+const DatabaseFix = lazyWithRetry(() => import("./pages/DatabaseFix"));
+const CompanyIdConsolidation = lazyWithRetry(() => import("./pages/CompanyIdConsolidation"));
 
 // Error boundary class component to catch module loading errors
-class AppErrorBoundary extends Component<
+export class AppErrorBoundary extends Component<
   { children: ReactNode },
   { hasError: boolean; error: Error | null }
 > {
@@ -74,26 +93,13 @@ class AppErrorBoundary extends Component<
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('App Error:', error, errorInfo);
 
-    // Check if this is a module loading error
     const isModuleError =
       error.message.includes('dynamically imported module') ||
       error.message.includes('Failed to fetch') ||
       error.message.includes('network');
 
     if (isModuleError) {
-      console.warn('⚠️ Module loading error detected - attempting recovery');
-      console.warn('Error details:', error.message);
-      console.warn('This may be due to:');
-      console.warn('1. Network connectivity issues');
-      console.warn('2. Browser cache issues');
-      console.warn('3. Dev server configuration issues');
-
-      // Clear service worker cache if available
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.getRegistrations().then(registrations => {
-          registrations.forEach(reg => reg.unregister());
-        }).catch(err => console.warn('Could not clear service workers:', err));
-      }
+      console.warn('Module loading error detected after retry attempts:', error.message);
     }
   }
 
@@ -108,67 +114,26 @@ class AppErrorBoundary extends Component<
 
 // Error recovery component for module loading failures
 const ModuleErrorFallback = () => {
-  const [retryCount, setRetryCount] = useState(0);
-  const [isClearing, setIsClearing] = useState(false);
-
   const handleRetry = () => {
-    setRetryCount(prev => prev + 1);
     window.location.reload();
-  };
-
-  const handleHardRefresh = async () => {
-    setIsClearing(true);
-    try {
-      // Clear all caches
-      if ('caches' in window) {
-        const cacheNames = await caches.keys();
-        await Promise.all(cacheNames.map(name => caches.delete(name)));
-      }
-
-      // Force hard refresh (Ctrl+Shift+R equivalent)
-      window.location.reload(true);
-    } catch (err) {
-      console.error('Error clearing cache:', err);
-      // Fallback to normal reload
-      window.location.reload();
-    } finally {
-      setIsClearing(false);
-    }
   };
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background">
       <div className="max-w-md w-full p-6 space-y-4">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-foreground">Module Loading Error</h1>
+          <h1 className="text-2xl font-bold text-foreground">This page could not be loaded</h1>
           <p className="text-muted-foreground">
-            There was an issue loading the page content. This can happen if the connection was interrupted or your browser cache is outdated.
+            The connection was interrupted while loading this page. Try again or return to the home page.
           </p>
-        </div>
-
-        <div className="bg-destructive/10 border border-destructive/20 rounded p-4">
-          <p className="text-sm text-destructive/80 font-medium mb-2">Troubleshooting steps:</p>
-          <ul className="text-xs text-destructive/70 space-y-1">
-            <li>• Check your internet connection</li>
-            <li>• Try a hard refresh (Ctrl+Shift+R)</li>
-            <li>• Clear your browser cache</li>
-            <li>• Try a different browser</li>
-          </ul>
         </div>
 
         <div className="flex flex-col gap-2">
           <button
-            onClick={handleHardRefresh}
-            disabled={isClearing}
-            className="w-full px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors font-medium disabled:opacity-50"
-          >
-            {isClearing ? 'Clearing cache...' : 'Hard Refresh (Clear Cache)'}
-          </button>
-          <button
             onClick={handleRetry}
-            className="w-full px-4 py-2 bg-secondary text-secondary-foreground rounded hover:bg-secondary/90 transition-colors font-medium"
+            className="w-full px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors font-medium"
           >
-            Soft Refresh
+            Try again
           </button>
           <button
             onClick={() => window.location.href = '/'}
@@ -178,11 +143,6 @@ const ModuleErrorFallback = () => {
           </button>
         </div>
 
-        {retryCount > 0 && (
-          <p className="text-xs text-muted-foreground text-center">
-            Refresh attempts: {retryCount}
-          </p>
-        )}
       </div>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import { CompanyProvider } from '@/contexts/CompanyContext';
 import { AuthErrorBoundary } from '@/components/auth/AuthErrorBoundary';
 import { enableResizeObserverErrorSuppression } from '@/utils/resizeObserverErrorHandler';
 import { HelmetProvider } from 'react-helmet-async';
-import App from './App.tsx'
+import App, { AppErrorBoundary } from './App.tsx'
 import './index.css'
 
 // Suppress ResizeObserver errors before any components render
@@ -30,7 +30,9 @@ createRoot(document.getElementById("root")!).render(
         <AuthProvider>
           <CompanyProvider>
             <BrowserRouter>
-              <App />
+              <AppErrorBoundary>
+                <App />
+              </AppErrorBoundary>
             </BrowserRouter>
           </CompanyProvider>
         </AuthProvider>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,11 +9,6 @@ export default defineConfig(({ mode }) => {
       host: "::",
       port: 5173,
       middlewareMode: false,
-      // HMR configuration: let the browser determine the host/port automatically
-      // This fixes module loading issues in proxied environments like builder.io
-      hmr: {
-        protocol: "ws",
-      },
     },
     plugins: [
       react(),


### PR DESCRIPTION
### Summary
Adds a Render Blueprint for SPA routing support and hardens client-side page loading with automatic retries and a top-level error boundary.

### Problem
The app is a Vite + React SPA using `BrowserRouter`. While the root URL worked on Render, direct navigation or refresh on nested routes (e.g. `/quotations`) failed because Render had no host-level rewrite rule to hand client-side URLs to React Router. The existing `.htaccess` rewrite is Apache-specific and has no effect on Render Static Sites. Additionally, dynamically imported page chunks could fail to load (e.g. due to transient network issues), causing unrecoverable errors.

### Solution
- Added a `render.yaml` Blueprint that configures the app as a static site, builds it with Vite, and rewrites all paths to `index.html` so Render serves the SPA shell and lets React Router handle the requested path.
- Wrapped lazy page imports with a retry helper to recover from transient chunk-loading failures.
- Moved the app-level error boundary up to `main.tsx` so it wraps the whole `App`, and simplified the fallback UI shown on unrecoverable module loading errors.
- Removed a stale Vite dev-server HMR override that isn't needed and could interfere with proxied environments.

### Key Changes
- **render.yaml**: New Render static site service with `npm ci && npm run build`, `dist` publish path, and a `/*` → `/index.html` rewrite rule.
- **src/App.tsx**: Introduced `lazyWithRetry` utility (up to 2 retries with backoff) and switched all page lazy imports to use it; exported `AppErrorBoundary`; simplified `componentDidCatch` logic and removed service worker cache clearing; simplified `ModuleErrorFallback` UI (removed hard-refresh/cache-clearing controls and retry count display, updated copy to "Try again").
- **src/main.tsx**: Imported `AppErrorBoundary` from `App.tsx` and wrapped `<App />` with it inside `BrowserRouter`.
- **vite.config.ts**: Removed the explicit `hmr: { protocol: "ws" }` dev server override.


---

<a href="https://builder.io/app/projects/07aeb346bc6046cbb062/onyx-handle-oapucyyi"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://07aeb346bc6046cbb062-onyx-handle-oapucyyi.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=07aeb346bc6046cbb062&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 353`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>07aeb346bc6046cbb062</projectId>-->
<!--<branchName>onyx-handle-oapucyyi</branchName>-->